### PR TITLE
feat: field-level audit log service + 26 tests (#8)

### DIFF
--- a/lib/audit/audit-service.ts
+++ b/lib/audit/audit-service.ts
@@ -1,0 +1,169 @@
+import type { PrismaClient } from "@prisma/client";
+import type {
+  AuditArchiveInput,
+  AuditCreateInput,
+  AuditEntryInput,
+  AuditSource,
+  AuditableTable,
+  FieldChange
+} from "./types";
+
+/**
+ * Field-level audit logging service.
+ *
+ * Design principles:
+ * - Append-only: audit entries are never modified or deleted.
+ * - Resilient: audit failures are logged to console but don't break the mutation.
+ *   (A failed audit write should not roll back a valid business operation.)
+ * - Batch-friendly: multiple field changes for one record are written as separate rows
+ *   in a single transaction for consistency.
+ */
+export class AuditService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Log field-level changes for an update operation.
+   * Creates one audit row per changed field.
+   * Skips silently if there are no changes.
+   */
+  async logUpdate(input: AuditEntryInput): Promise<void> {
+    if (input.changes.length === 0) return;
+
+    try {
+      await this.writeEntries(
+        input.userId,
+        input.tableName,
+        input.recordId,
+        input.changes,
+        input.reason ?? null,
+        input.source
+      );
+    } catch (error) {
+      console.error("[AuditService] Failed to write update audit entries:", error);
+    }
+  }
+
+  /**
+   * Log all fields for a newly created record.
+   * Each field gets an entry with oldValue=null and newValue=current.
+   */
+  async logCreate(input: AuditCreateInput): Promise<void> {
+    const changes: FieldChange[] = Object.entries(input.fields)
+      .filter(([, value]) => value !== null && value !== undefined)
+      .map(([field, value]) => ({
+        field,
+        oldValue: null,
+        newValue: value
+      }));
+
+    if (changes.length === 0) return;
+
+    try {
+      await this.writeEntries(
+        input.userId,
+        input.tableName,
+        input.recordId,
+        changes,
+        null,
+        input.source
+      );
+    } catch (error) {
+      console.error("[AuditService] Failed to write create audit entries:", error);
+    }
+  }
+
+  /**
+   * Log an archive (soft-delete) operation.
+   * Records the isActive field change from true to false.
+   */
+  async logArchive(input: AuditArchiveInput): Promise<void> {
+    const changes: FieldChange[] = [{ field: "isActive", oldValue: "true", newValue: "false" }];
+
+    try {
+      await this.writeEntries(
+        input.userId,
+        input.tableName,
+        input.recordId,
+        changes,
+        input.reason ?? null,
+        input.source
+      );
+    } catch (error) {
+      console.error("[AuditService] Failed to write archive audit entries:", error);
+    }
+  }
+
+  /**
+   * Log a snapshot status change (draft → locked or locked → draft).
+   */
+  async logSnapshotStatusChange(
+    userId: string | null,
+    snapshotId: string,
+    oldStatus: string,
+    newStatus: string,
+    reason: string | null,
+    source: AuditSource
+  ): Promise<void> {
+    const changes: FieldChange[] = [{ field: "status", oldValue: oldStatus, newValue: newStatus }];
+
+    try {
+      await this.writeEntries(userId, "Snapshot", snapshotId, changes, reason, source);
+    } catch (error) {
+      console.error("[AuditService] Failed to write snapshot status audit:", error);
+    }
+  }
+
+  /**
+   * Query audit history for a specific record.
+   * Returns entries ordered by timestamp descending (most recent first).
+   */
+  async getHistory(tableName: AuditableTable, recordId: string, limit = 100) {
+    return this.prisma.auditLog.findMany({
+      where: { tableName, recordId },
+      orderBy: { timestamp: "desc" },
+      take: limit,
+      include: { user: { select: { id: true, name: true, email: true } } }
+    });
+  }
+
+  /**
+   * Query audit history for a specific field on a specific record.
+   */
+  async getFieldHistory(tableName: AuditableTable, recordId: string, field: string, limit = 50) {
+    return this.prisma.auditLog.findMany({
+      where: { tableName, recordId, field },
+      orderBy: { timestamp: "desc" },
+      take: limit,
+      include: { user: { select: { id: true, name: true, email: true } } }
+    });
+  }
+
+  /**
+   * Internal: write audit entries in a batch.
+   * Uses createMany for efficiency — all entries get the same timestamp.
+   */
+  private async writeEntries(
+    userId: string | null,
+    tableName: AuditableTable,
+    recordId: string,
+    changes: FieldChange[],
+    reason: string | null,
+    source: AuditSource
+  ): Promise<void> {
+    const now = new Date();
+
+    await this.prisma.auditLog.createMany({
+      data: changes.map((change) => ({
+        userId,
+        tableName,
+        recordId,
+        field: change.field,
+        oldValue: change.oldValue,
+        newValue: change.newValue,
+        reason,
+        source,
+        timestamp: now
+      }))
+    });
+  }
+}

--- a/lib/audit/index.ts
+++ b/lib/audit/index.ts
@@ -1,0 +1,10 @@
+export { AuditService } from "./audit-service";
+export { diffFields } from "./types";
+export type {
+  AuditArchiveInput,
+  AuditCreateInput,
+  AuditEntryInput,
+  AuditSource,
+  AuditableTable,
+  FieldChange
+} from "./types";

--- a/lib/audit/types.ts
+++ b/lib/audit/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Audit source taxonomy — must stay in sync with AuditSource enum in prisma/schema.prisma.
+ */
+export type AuditSource = "ui_edit" | "import" | "bulk_action" | "api";
+
+/**
+ * Tables that support audit logging.
+ * Matches the Prisma model names used in tableName field.
+ */
+export type AuditableTable = "Group" | "LineItem" | "Snapshot" | "Value";
+
+/**
+ * A single field-level change to be logged.
+ */
+export interface FieldChange {
+  field: string;
+  oldValue: string | null;
+  newValue: string | null;
+}
+
+/**
+ * Input for creating audit log entries.
+ */
+export interface AuditEntryInput {
+  userId: string | null;
+  tableName: AuditableTable;
+  recordId: string;
+  changes: FieldChange[];
+  reason?: string;
+  source: AuditSource;
+}
+
+/**
+ * Input for logging a record creation (all fields are "new").
+ */
+export interface AuditCreateInput {
+  userId: string | null;
+  tableName: AuditableTable;
+  recordId: string;
+  fields: Record<string, string | null>;
+  source: AuditSource;
+}
+
+/**
+ * Input for logging a record archive/soft-delete.
+ */
+export interface AuditArchiveInput {
+  userId: string | null;
+  tableName: AuditableTable;
+  recordId: string;
+  reason?: string;
+  source: AuditSource;
+}
+
+/**
+ * Compares two objects and returns the field-level changes between them.
+ * Only includes fields that actually changed.
+ * Values are coerced to strings for storage (Decimal, Date, boolean, etc.).
+ */
+export function diffFields(
+  oldRecord: Record<string, unknown>,
+  newRecord: Record<string, unknown>,
+  fieldsToTrack: string[]
+): FieldChange[] {
+  const changes: FieldChange[] = [];
+
+  for (const field of fieldsToTrack) {
+    const oldVal = serializeValue(oldRecord[field]);
+    const newVal = serializeValue(newRecord[field]);
+
+    if (oldVal !== newVal) {
+      changes.push({ field, oldValue: oldVal, newValue: newVal });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Serialize a value to a string for audit storage.
+ * Returns null for null/undefined.
+ */
+function serializeValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object" && "toFixed" in value) {
+    // Prisma Decimal type
+    return String(value);
+  }
+  return String(value);
+}

--- a/tests/unit/audit-service.test.ts
+++ b/tests/unit/audit-service.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AuditService, diffFields } from "../../lib/audit";
+import type { FieldChange } from "../../lib/audit";
+
+// ---------------------------------------------------------------------------
+// diffFields — pure function tests
+// ---------------------------------------------------------------------------
+describe("diffFields", () => {
+  it("detects changed string fields", () => {
+    const old = { name: "Rent", sortOrder: "1" };
+    const updated = { name: "Rental Income", sortOrder: "1" };
+    const changes = diffFields(old, updated, ["name", "sortOrder"]);
+
+    expect(changes).toEqual([{ field: "name", oldValue: "Rent", newValue: "Rental Income" }]);
+  });
+
+  it("detects changed numeric fields (coerced to string)", () => {
+    const old = { sortOrder: 1 };
+    const updated = { sortOrder: 2 };
+    const changes = diffFields(old, updated, ["sortOrder"]);
+
+    expect(changes).toEqual([{ field: "sortOrder", oldValue: "1", newValue: "2" }]);
+  });
+
+  it("detects null to value change", () => {
+    const old = { note: null };
+    const updated = { note: "Updated forecast" };
+    const changes = diffFields(old, updated, ["note"]);
+
+    expect(changes).toEqual([{ field: "note", oldValue: null, newValue: "Updated forecast" }]);
+  });
+
+  it("detects value to null change", () => {
+    const old = { note: "Some note" };
+    const updated = { note: null };
+    const changes = diffFields(old, updated, ["note"]);
+
+    expect(changes).toEqual([{ field: "note", oldValue: "Some note", newValue: null }]);
+  });
+
+  it("returns empty array when nothing changed", () => {
+    const old = { name: "Rent", sortOrder: 1 };
+    const updated = { name: "Rent", sortOrder: 1 };
+    const changes = diffFields(old, updated, ["name", "sortOrder"]);
+
+    expect(changes).toEqual([]);
+  });
+
+  it("only tracks specified fields", () => {
+    const old = { name: "Rent", sortOrder: 1, groupType: "sector" };
+    const updated = { name: "Rental", sortOrder: 2, groupType: "custom" };
+    const changes = diffFields(old, updated, ["name"]);
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0].field).toBe("name");
+  });
+
+  it("handles undefined fields as null", () => {
+    const old = {} as Record<string, unknown>;
+    const updated = { name: "New" };
+    const changes = diffFields(old, updated, ["name"]);
+
+    expect(changes).toEqual([{ field: "name", oldValue: null, newValue: "New" }]);
+  });
+
+  it("serializes Date objects to ISO strings", () => {
+    const date1 = new Date("2026-01-15T00:00:00.000Z");
+    const date2 = new Date("2026-02-15T00:00:00.000Z");
+    const old = { archivedAt: date1 };
+    const updated = { archivedAt: date2 };
+    const changes = diffFields(old, updated, ["archivedAt"]);
+
+    expect(changes).toEqual([
+      {
+        field: "archivedAt",
+        oldValue: "2026-01-15T00:00:00.000Z",
+        newValue: "2026-02-15T00:00:00.000Z"
+      }
+    ]);
+  });
+
+  it("serializes boolean fields", () => {
+    const old = { isActive: true };
+    const updated = { isActive: false };
+    const changes = diffFields(old, updated, ["isActive"]);
+
+    expect(changes).toEqual([{ field: "isActive", oldValue: "true", newValue: "false" }]);
+  });
+
+  it("handles Decimal-like objects with toFixed", () => {
+    const decimalLike = { toFixed: () => "1234.56", toString: () => "1234.56" };
+    const old = { amount: decimalLike };
+    const updated = { amount: { toFixed: () => "2000.00", toString: () => "2000.00" } };
+    const changes = diffFields(old, updated, ["amount"]);
+
+    expect(changes).toHaveLength(1);
+    expect(changes[0].field).toBe("amount");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuditService — mock Prisma tests
+// ---------------------------------------------------------------------------
+describe("AuditService", () => {
+  const mockCreateMany = vi.fn().mockResolvedValue({ count: 0 });
+  const mockFindMany = vi.fn().mockResolvedValue([]);
+  const mockPrisma = {
+    auditLog: {
+      createMany: mockCreateMany,
+      findMany: mockFindMany
+    }
+  } as never;
+
+  let service: AuditService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new AuditService(mockPrisma);
+  });
+
+  describe("logUpdate", () => {
+    it("writes one audit row per changed field", async () => {
+      const changes: FieldChange[] = [
+        { field: "name", oldValue: "Old", newValue: "New" },
+        { field: "sortOrder", oldValue: "1", newValue: "2" }
+      ];
+
+      await service.logUpdate({
+        userId: "user-1",
+        tableName: "Group",
+        recordId: "group-1",
+        changes,
+        reason: "Reorganizing",
+        source: "ui_edit"
+      });
+
+      expect(mockCreateMany).toHaveBeenCalledOnce();
+      const call = mockCreateMany.mock.calls[0][0];
+      expect(call.data).toHaveLength(2);
+      expect(call.data[0]).toMatchObject({
+        userId: "user-1",
+        tableName: "Group",
+        recordId: "group-1",
+        field: "name",
+        oldValue: "Old",
+        newValue: "New",
+        reason: "Reorganizing",
+        source: "ui_edit"
+      });
+      expect(call.data[1].field).toBe("sortOrder");
+    });
+
+    it("skips when no changes", async () => {
+      await service.logUpdate({
+        userId: "user-1",
+        tableName: "Group",
+        recordId: "group-1",
+        changes: [],
+        source: "ui_edit"
+      });
+
+      expect(mockCreateMany).not.toHaveBeenCalled();
+    });
+
+    it("does not throw on Prisma error", async () => {
+      mockCreateMany.mockRejectedValueOnce(new Error("DB connection lost"));
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      await expect(
+        service.logUpdate({
+          userId: "user-1",
+          tableName: "Value",
+          recordId: "val-1",
+          changes: [{ field: "projectedAmount", oldValue: "100", newValue: "200" }],
+          source: "ui_edit"
+        })
+      ).resolves.toBeUndefined();
+
+      expect(consoleSpy).toHaveBeenCalledOnce();
+      consoleSpy.mockRestore();
+    });
+
+    it("sets reason to null when not provided", async () => {
+      await service.logUpdate({
+        userId: "user-1",
+        tableName: "LineItem",
+        recordId: "li-1",
+        changes: [{ field: "label", oldValue: "A", newValue: "B" }],
+        source: "api"
+      });
+
+      expect(mockCreateMany.mock.calls[0][0].data[0].reason).toBeNull();
+    });
+  });
+
+  describe("logCreate", () => {
+    it("writes entries for all non-null fields", async () => {
+      await service.logCreate({
+        userId: "user-1",
+        tableName: "Group",
+        recordId: "group-new",
+        fields: { name: "Storage Center", groupType: "sector", sortOrder: "3" },
+        source: "ui_edit"
+      });
+
+      expect(mockCreateMany).toHaveBeenCalledOnce();
+      const data = mockCreateMany.mock.calls[0][0].data;
+      expect(data).toHaveLength(3);
+      expect(data.every((d: Record<string, unknown>) => d.oldValue === null)).toBe(true);
+      expect(data.map((d: Record<string, unknown>) => d.field)).toEqual(
+        expect.arrayContaining(["name", "groupType", "sortOrder"])
+      );
+    });
+
+    it("filters out null/undefined fields", async () => {
+      await service.logCreate({
+        userId: "user-1",
+        tableName: "LineItem",
+        recordId: "li-new",
+        fields: { label: "New Item", projectionParams: null },
+        source: "ui_edit"
+      });
+
+      const data = mockCreateMany.mock.calls[0][0].data;
+      expect(data).toHaveLength(1);
+      expect(data[0].field).toBe("label");
+    });
+
+    it("skips when all fields are null", async () => {
+      await service.logCreate({
+        userId: "user-1",
+        tableName: "LineItem",
+        recordId: "li-new",
+        fields: { note: null },
+        source: "ui_edit"
+      });
+
+      expect(mockCreateMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("logArchive", () => {
+    it("logs isActive change from true to false", async () => {
+      await service.logArchive({
+        userId: "user-1",
+        tableName: "Group",
+        recordId: "group-1",
+        reason: "No longer needed",
+        source: "ui_edit"
+      });
+
+      expect(mockCreateMany).toHaveBeenCalledOnce();
+      const data = mockCreateMany.mock.calls[0][0].data;
+      expect(data).toHaveLength(1);
+      expect(data[0]).toMatchObject({
+        field: "isActive",
+        oldValue: "true",
+        newValue: "false",
+        reason: "No longer needed"
+      });
+    });
+  });
+
+  describe("logSnapshotStatusChange", () => {
+    it("logs status transition", async () => {
+      await service.logSnapshotStatusChange(
+        "admin-1",
+        "snap-1",
+        "draft",
+        "locked",
+        "Month-end close",
+        "ui_edit"
+      );
+
+      expect(mockCreateMany).toHaveBeenCalledOnce();
+      const data = mockCreateMany.mock.calls[0][0].data;
+      expect(data[0]).toMatchObject({
+        userId: "admin-1",
+        tableName: "Snapshot",
+        field: "status",
+        oldValue: "draft",
+        newValue: "locked",
+        reason: "Month-end close"
+      });
+    });
+  });
+
+  describe("getHistory", () => {
+    it("queries with correct params and default limit", async () => {
+      await service.getHistory("Value", "val-1");
+
+      expect(mockFindMany).toHaveBeenCalledWith({
+        where: { tableName: "Value", recordId: "val-1" },
+        orderBy: { timestamp: "desc" },
+        take: 100,
+        include: { user: { select: { id: true, name: true, email: true } } }
+      });
+    });
+
+    it("respects custom limit", async () => {
+      await service.getHistory("Group", "grp-1", 25);
+
+      expect(mockFindMany.mock.calls[0][0].take).toBe(25);
+    });
+  });
+
+  describe("getFieldHistory", () => {
+    it("queries for specific field", async () => {
+      await service.getFieldHistory("Value", "val-1", "projectedAmount");
+
+      expect(mockFindMany).toHaveBeenCalledWith({
+        where: { tableName: "Value", recordId: "val-1", field: "projectedAmount" },
+        orderBy: { timestamp: "desc" },
+        take: 50,
+        include: { user: { select: { id: true, name: true, email: true } } }
+      });
+    });
+  });
+
+  describe("source taxonomy", () => {
+    it.each(["ui_edit", "import", "bulk_action", "api"] as const)(
+      "accepts source: %s",
+      async (source) => {
+        await service.logUpdate({
+          userId: "user-1",
+          tableName: "Value",
+          recordId: "val-1",
+          changes: [{ field: "projectedAmount", oldValue: "100", newValue: "200" }],
+          source
+        });
+
+        expect(mockCreateMany.mock.calls[0][0].data[0].source).toBe(source);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implements an append-only field-level audit logging service that all mutation paths (groups, line items, snapshots, values) will call. This is a foundational service — subsequent features integrate with it.

**AuditService methods:**
- `logUpdate(input)` — logs per-field old→new changes for update operations
- `logCreate(input)` — logs all non-null fields for new records (oldValue=null)
- `logArchive(input)` — logs isActive true→false with optional reason
- `logSnapshotStatusChange(...)` — logs draft↔locked transitions
- `getHistory(table, recordId)` — query audit trail for a record
- `getFieldHistory(table, recordId, field)` — query a single field's history

**diffFields utility:**
- Compares two objects and returns field-level changes
- Serializes Dates, Decimals, booleans to strings for consistent storage
- Only tracks specified fields (caller controls what's auditable)

**Design decisions:**
- **Resilient:** audit failures log to console but never break business operations
- **Batch writes:** `createMany` for multiple field changes (same timestamp)
- **Source tracking:** every entry includes source (ui_edit, import, bulk_action, api) per ADR in DECISIONS.md

## Files

| File | Purpose |
|-|-|
| `lib/audit/types.ts` | Type definitions, `diffFields` utility |
| `lib/audit/audit-service.ts` | AuditService class |
| `lib/audit/index.ts` | Barrel export |
| `tests/unit/audit-service.test.ts` | 26 unit tests |

## Test plan

- [x] 53 total tests passing (26 audit + 26 projection + 1 smoke)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)