### PR TITLE
feat: snapshot CRUD service with lock/unlock/copy workflow

### DIFF
--- a/lib/snapshots/index.ts
+++ b/lib/snapshots/index.ts
@@ -1,0 +1,8 @@
+export { SnapshotService } from "./snapshot-service";
+export type {
+  CopySnapshotInput,
+  CreateSnapshotInput,
+  LockSnapshotInput,
+  UnlockSnapshotInput
+} from "./types";
+export { parseAsOfMonth } from "./types";

--- a/lib/snapshots/snapshot-service.ts
+++ b/lib/snapshots/snapshot-service.ts
@@ -1,0 +1,223 @@
+import type { PrismaClient } from "@prisma/client";
+
+type TxClient = Omit<
+  PrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>;
+import type { AuditService } from "../audit";
+import type {
+  CopySnapshotInput,
+  CreateSnapshotInput,
+  LockSnapshotInput,
+  UnlockSnapshotInput
+} from "./types";
+import { parseAsOfMonth } from "./types";
+
+/**
+ * Snapshot lifecycle service.
+ *
+ * Snapshots progress through: draft → locked (→ draft if reopened).
+ * Locking captures a StructureVersion so the report shape is reproducible.
+ * Copying creates a new draft pre-filled with the source's projected values
+ * (actuals are NOT copied — per ADR-003 new snapshots start fresh).
+ */
+export class SnapshotService {
+  constructor(
+    private prisma: PrismaClient,
+    private audit: AuditService
+  ) {}
+
+  /**
+   * Create a new draft snapshot.
+   */
+  async create(input: CreateSnapshotInput) {
+    const snapshot = await this.prisma.snapshot.create({
+      data: {
+        name: input.name,
+        asOfMonth: parseAsOfMonth(input.asOfMonth),
+        status: "draft",
+        createdBy: input.createdBy
+      }
+    });
+
+    await this.audit.logCreate({
+      userId: input.createdBy,
+      tableName: "Snapshot",
+      recordId: snapshot.id,
+      fields: {
+        name: input.name,
+        asOfMonth: input.asOfMonth,
+        status: "draft"
+      },
+      source: "ui_edit"
+    });
+
+    return snapshot;
+  }
+
+  /**
+   * Lock a draft snapshot (admin-only).
+   * Creates a StructureVersion capturing the current report shape.
+   */
+  async lock(input: LockSnapshotInput) {
+    const snapshot = await this.prisma.snapshot.findUniqueOrThrow({
+      where: { id: input.snapshotId }
+    });
+
+    if (snapshot.status === "locked") {
+      throw new Error("Snapshot is already locked");
+    }
+
+    // Create structure version and update snapshot in a transaction
+    const result = await this.prisma.$transaction(async (tx: TxClient) => {
+      const structureVersion = await tx.structureVersion.create({
+        data: { snapshotId: snapshot.id }
+      });
+
+      const updated = await tx.snapshot.update({
+        where: { id: snapshot.id },
+        data: {
+          status: "locked",
+          lockedBy: input.lockedBy,
+          lockedAt: new Date(),
+          structureVersionId: structureVersion.id
+        }
+      });
+
+      return updated;
+    });
+
+    await this.audit.logSnapshotStatusChange(
+      input.lockedBy,
+      snapshot.id,
+      "draft",
+      "locked",
+      input.reason ?? null,
+      "ui_edit"
+    );
+
+    return result;
+  }
+
+  /**
+   * Unlock (reopen) a locked snapshot (admin-only).
+   * Sets status back to draft. Does NOT delete the StructureVersion.
+   */
+  async unlock(input: UnlockSnapshotInput) {
+    const snapshot = await this.prisma.snapshot.findUniqueOrThrow({
+      where: { id: input.snapshotId }
+    });
+
+    if (snapshot.status === "draft") {
+      throw new Error("Snapshot is already unlocked");
+    }
+
+    const updated = await this.prisma.snapshot.update({
+      where: { id: snapshot.id },
+      data: {
+        status: "draft",
+        lockedBy: null,
+        lockedAt: null
+      }
+    });
+
+    await this.audit.logSnapshotStatusChange(
+      input.unlockedBy,
+      snapshot.id,
+      "locked",
+      "draft",
+      input.reason ?? null,
+      "ui_edit"
+    );
+
+    return updated;
+  }
+
+  /**
+   * Copy a locked snapshot's projected values into a new draft.
+   * Actuals are NOT copied (ADR-003: new snapshots start fresh for actuals).
+   */
+  async copyFromPrior(input: CopySnapshotInput) {
+    const source = await this.prisma.snapshot.findUniqueOrThrow({
+      where: { id: input.sourceSnapshotId }
+    });
+
+    if (source.status !== "locked") {
+      throw new Error("Can only copy from a locked snapshot");
+    }
+
+    const sourceValues = await this.prisma.value.findMany({
+      where: { snapshotId: source.id }
+    });
+
+    const result = await this.prisma.$transaction(async (tx: TxClient) => {
+      const newSnapshot = await tx.snapshot.create({
+        data: {
+          name: input.name,
+          asOfMonth: parseAsOfMonth(input.asOfMonth),
+          status: "draft",
+          createdBy: input.createdBy
+        }
+      });
+
+      if (sourceValues.length > 0) {
+        await tx.value.createMany({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          data: sourceValues.map((v: any) => ({
+            lineItemId: v.lineItemId,
+            snapshotId: newSnapshot.id,
+            period: v.period,
+            projectedAmount: v.projectedAmount,
+            actualAmount: null,
+            note: null,
+            updatedBy: input.createdBy
+          }))
+        });
+      }
+
+      return newSnapshot;
+    });
+
+    await this.audit.logCreate({
+      userId: input.createdBy,
+      tableName: "Snapshot",
+      recordId: result.id,
+      fields: {
+        name: input.name,
+        asOfMonth: input.asOfMonth,
+        status: "draft",
+        copiedFrom: input.sourceSnapshotId
+      },
+      source: "ui_edit"
+    });
+
+    return result;
+  }
+
+  /**
+   * List all snapshots, ordered by creation date descending.
+   */
+  async list() {
+    return this.prisma.snapshot.findMany({
+      orderBy: { createdAt: "desc" },
+      include: {
+        creator: { select: { id: true, name: true, email: true } },
+        locker: { select: { id: true, name: true, email: true } }
+      }
+    });
+  }
+
+  /**
+   * Get a single snapshot by ID with related data.
+   */
+  async getById(snapshotId: string) {
+    return this.prisma.snapshot.findUniqueOrThrow({
+      where: { id: snapshotId },
+      include: {
+        creator: { select: { id: true, name: true, email: true } },
+        locker: { select: { id: true, name: true, email: true } },
+        structureVersion: true
+      }
+    });
+  }
+}

--- a/lib/snapshots/types.ts
+++ b/lib/snapshots/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Input for creating a new snapshot.
+ */
+export interface CreateSnapshotInput {
+  name: string;
+  /** YYYY-MM format, e.g., "2026-03" */
+  asOfMonth: string;
+  createdBy: string;
+}
+
+/**
+ * Input for locking a snapshot (admin-only).
+ */
+export interface LockSnapshotInput {
+  snapshotId: string;
+  lockedBy: string;
+  reason?: string;
+}
+
+/**
+ * Input for unlocking a snapshot (admin-only).
+ */
+export interface UnlockSnapshotInput {
+  snapshotId: string;
+  unlockedBy: string;
+  reason?: string;
+}
+
+/**
+ * Input for copying a snapshot from a prior locked version.
+ * Creates a new draft snapshot pre-filled with the source's projected values.
+ * Actual amounts are NOT copied (per ADR-003: new snapshots start fresh for actuals).
+ */
+export interface CopySnapshotInput {
+  sourceSnapshotId: string;
+  name: string;
+  /** YYYY-MM format for the new snapshot's as-of month */
+  asOfMonth: string;
+  createdBy: string;
+}
+
+/**
+ * Converts a YYYY-MM string to a Date (first day of the month, UTC).
+ */
+export function parseAsOfMonth(asOfMonth: string): Date {
+  const [year, month] = asOfMonth.split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, 1));
+}

--- a/tests/unit/snapshot-service.test.ts
+++ b/tests/unit/snapshot-service.test.ts
@@ -1,0 +1,536 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { SnapshotService } from "../../lib/snapshots";
+import { parseAsOfMonth } from "../../lib/snapshots/types";
+
+// ---------------------------------------------------------------------------
+// parseAsOfMonth — pure function tests
+// ---------------------------------------------------------------------------
+describe("parseAsOfMonth", () => {
+  it("converts YYYY-MM to first day of month UTC", () => {
+    const d = parseAsOfMonth("2026-03");
+    expect(d.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("handles January", () => {
+    const d = parseAsOfMonth("2026-01");
+    expect(d.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("handles December", () => {
+    const d = parseAsOfMonth("2025-12");
+    expect(d.toISOString()).toBe("2025-12-01T00:00:00.000Z");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+function createMockAudit() {
+  return {
+    logCreate: vi.fn().mockResolvedValue(undefined),
+    logSnapshotStatusChange: vi.fn().mockResolvedValue(undefined)
+  } as never;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createMockPrisma(overrides: Record<string, any> = {}): any {
+  return {
+    snapshot: {
+      create: vi.fn().mockResolvedValue({
+        id: "snap-new",
+        name: "Q1 2026",
+        asOfMonth: new Date("2026-03-01T00:00:00.000Z"),
+        status: "draft",
+        createdBy: "user-1",
+        lockedBy: null,
+        lockedAt: null,
+        structureVersionId: null,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }),
+      findUniqueOrThrow: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn()
+    },
+    value: {
+      findMany: vi.fn().mockResolvedValue([]),
+      createMany: vi.fn().mockResolvedValue({ count: 0 })
+    },
+    structureVersion: {
+      create: vi.fn().mockResolvedValue({ id: "sv-1", snapshotId: "snap-1" })
+    },
+    $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+      const self = createMockPrisma(overrides);
+      if (overrides.txSnapshotCreate) {
+        self.snapshot.create = overrides.txSnapshotCreate;
+      }
+      if (overrides.txValueCreateMany) {
+        self.value.createMany = overrides.txValueCreateMany;
+      }
+      return fn(self);
+    }),
+    ...overrides
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SnapshotService tests
+// ---------------------------------------------------------------------------
+describe("SnapshotService", () => {
+  let service: SnapshotService;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+  let mockAudit: ReturnType<typeof createMockAudit>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAudit = createMockAudit();
+    mockPrisma = createMockPrisma();
+    service = new SnapshotService(mockPrisma, mockAudit);
+  });
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+  describe("create", () => {
+    it("creates a draft snapshot", async () => {
+      const result = await service.create({
+        name: "Q1 2026",
+        asOfMonth: "2026-03",
+        createdBy: "user-1"
+      });
+
+      expect(result.id).toBe("snap-new");
+      expect(result.status).toBe("draft");
+
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      const createCall = prismaAny.snapshot.create.mock.calls[0][0];
+      expect(createCall.data.name).toBe("Q1 2026");
+      expect(createCall.data.status).toBe("draft");
+      expect(createCall.data.asOfMonth).toEqual(new Date("2026-03-01T00:00:00.000Z"));
+    });
+
+    it("logs creation via audit service", async () => {
+      await service.create({
+        name: "Q1 2026",
+        asOfMonth: "2026-03",
+        createdBy: "user-1"
+      });
+
+      const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+      expect(auditAny.logCreate).toHaveBeenCalledOnce();
+      const auditCall = auditAny.logCreate.mock.calls[0][0];
+      expect(auditCall.tableName).toBe("Snapshot");
+      expect(auditCall.fields.name).toBe("Q1 2026");
+      expect(auditCall.fields.status).toBe("draft");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // lock
+  // -------------------------------------------------------------------------
+  describe("lock", () => {
+    it("locks a draft snapshot", async () => {
+      const draftSnapshot = {
+        id: "snap-1",
+        status: "draft",
+        name: "Q1 2026"
+      };
+      const lockedSnapshot = { ...draftSnapshot, status: "locked", lockedBy: "admin-1" };
+
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(draftSnapshot);
+
+      // Override $transaction to return the locked snapshot
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          structureVersion: {
+            create: vi.fn().mockResolvedValue({ id: "sv-1", snapshotId: "snap-1" })
+          },
+          snapshot: {
+            update: vi.fn().mockResolvedValue(lockedSnapshot)
+          }
+        };
+        return fn(tx);
+      }) as never;
+
+      // Re-create service with updated mock
+      service = new SnapshotService(mockPrisma, mockAudit);
+      const result = await service.lock({
+        snapshotId: "snap-1",
+        lockedBy: "admin-1",
+        reason: "Month-end close"
+      });
+
+      expect(result.status).toBe("locked");
+    });
+
+    it("throws when snapshot is already locked", async () => {
+      const lockedSnapshot = { id: "snap-1", status: "locked" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(lockedSnapshot);
+
+      await expect(service.lock({ snapshotId: "snap-1", lockedBy: "admin-1" })).rejects.toThrow(
+        "Snapshot is already locked"
+      );
+    });
+
+    it("logs status change via audit service", async () => {
+      const draftSnapshot = { id: "snap-1", status: "draft" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(draftSnapshot);
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          structureVersion: { create: vi.fn().mockResolvedValue({ id: "sv-1" }) },
+          snapshot: {
+            update: vi.fn().mockResolvedValue({ ...draftSnapshot, status: "locked" })
+          }
+        };
+        return fn(tx);
+      }) as never;
+      service = new SnapshotService(mockPrisma, mockAudit);
+
+      await service.lock({
+        snapshotId: "snap-1",
+        lockedBy: "admin-1",
+        reason: "Month-end close"
+      });
+
+      const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+      expect(auditAny.logSnapshotStatusChange).toHaveBeenCalledWith(
+        "admin-1",
+        "snap-1",
+        "draft",
+        "locked",
+        "Month-end close",
+        "ui_edit"
+      );
+    });
+
+    it("creates a structure version on lock", async () => {
+      const draftSnapshot = { id: "snap-1", status: "draft" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(draftSnapshot);
+
+      const mockSvCreate = vi.fn().mockResolvedValue({ id: "sv-1", snapshotId: "snap-1" });
+      const mockSnapUpdate = vi
+        .fn()
+        .mockResolvedValue({ ...draftSnapshot, status: "locked", structureVersionId: "sv-1" });
+
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          structureVersion: { create: mockSvCreate },
+          snapshot: { update: mockSnapUpdate }
+        };
+        return fn(tx);
+      }) as never;
+      service = new SnapshotService(mockPrisma, mockAudit);
+
+      await service.lock({ snapshotId: "snap-1", lockedBy: "admin-1" });
+
+      expect(mockSvCreate).toHaveBeenCalledWith({ data: { snapshotId: "snap-1" } });
+      expect(mockSnapUpdate.mock.calls[0][0].data.structureVersionId).toBe("sv-1");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // unlock
+  // -------------------------------------------------------------------------
+  describe("unlock", () => {
+    it("unlocks a locked snapshot", async () => {
+      const lockedSnapshot = { id: "snap-1", status: "locked", lockedBy: "admin-1" };
+      const unlockedSnapshot = {
+        ...lockedSnapshot,
+        status: "draft",
+        lockedBy: null,
+        lockedAt: null
+      };
+
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(lockedSnapshot);
+      prismaAny.snapshot.update.mockResolvedValue(unlockedSnapshot);
+
+      const result = await service.unlock({
+        snapshotId: "snap-1",
+        unlockedBy: "admin-1",
+        reason: "Need corrections"
+      });
+
+      expect(result.status).toBe("draft");
+      expect(result.lockedBy).toBeNull();
+    });
+
+    it("throws when snapshot is already unlocked", async () => {
+      const draftSnapshot = { id: "snap-1", status: "draft" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(draftSnapshot);
+
+      await expect(service.unlock({ snapshotId: "snap-1", unlockedBy: "admin-1" })).rejects.toThrow(
+        "Snapshot is already unlocked"
+      );
+    });
+
+    it("clears lockedBy and lockedAt on unlock", async () => {
+      const lockedSnapshot = {
+        id: "snap-1",
+        status: "locked",
+        lockedBy: "admin-1",
+        lockedAt: new Date()
+      };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(lockedSnapshot);
+      prismaAny.snapshot.update.mockResolvedValue({
+        ...lockedSnapshot,
+        status: "draft",
+        lockedBy: null,
+        lockedAt: null
+      });
+
+      await service.unlock({ snapshotId: "snap-1", unlockedBy: "admin-1" });
+
+      const updateCall = prismaAny.snapshot.update.mock.calls[0][0];
+      expect(updateCall.data.lockedBy).toBeNull();
+      expect(updateCall.data.lockedAt).toBeNull();
+    });
+
+    it("logs status change via audit service", async () => {
+      const lockedSnapshot = { id: "snap-1", status: "locked" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(lockedSnapshot);
+      prismaAny.snapshot.update.mockResolvedValue({ ...lockedSnapshot, status: "draft" });
+
+      await service.unlock({
+        snapshotId: "snap-1",
+        unlockedBy: "admin-1",
+        reason: "Need corrections"
+      });
+
+      const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+      expect(auditAny.logSnapshotStatusChange).toHaveBeenCalledWith(
+        "admin-1",
+        "snap-1",
+        "locked",
+        "draft",
+        "Need corrections",
+        "ui_edit"
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // copyFromPrior
+  // -------------------------------------------------------------------------
+  describe("copyFromPrior", () => {
+    it("creates a new draft from a locked snapshot", async () => {
+      const source = { id: "snap-old", status: "locked", name: "Q4 2025" };
+      const newSnapshot = { id: "snap-new", status: "draft", name: "Q1 2026" };
+
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(source);
+      prismaAny.value.findMany.mockResolvedValue([]);
+
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          snapshot: { create: vi.fn().mockResolvedValue(newSnapshot) },
+          value: { createMany: vi.fn().mockResolvedValue({ count: 0 }) }
+        };
+        return fn(tx);
+      }) as never;
+      service = new SnapshotService(mockPrisma, mockAudit);
+
+      const result = await service.copyFromPrior({
+        sourceSnapshotId: "snap-old",
+        name: "Q1 2026",
+        asOfMonth: "2026-03",
+        createdBy: "user-1"
+      });
+
+      expect(result.id).toBe("snap-new");
+      expect(result.status).toBe("draft");
+    });
+
+    it("throws when source is not locked", async () => {
+      const source = { id: "snap-old", status: "draft" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(source);
+
+      await expect(
+        service.copyFromPrior({
+          sourceSnapshotId: "snap-old",
+          name: "Q1 2026",
+          asOfMonth: "2026-03",
+          createdBy: "user-1"
+        })
+      ).rejects.toThrow("Can only copy from a locked snapshot");
+    });
+
+    it("copies projected values but NOT actuals (ADR-003)", async () => {
+      const source = { id: "snap-old", status: "locked" };
+      const sourceValues = [
+        {
+          id: "v1",
+          lineItemId: "li-1",
+          snapshotId: "snap-old",
+          period: new Date("2025-01-01"),
+          projectedAmount: 1000,
+          actualAmount: 950,
+          note: "original note",
+          updatedBy: "old-user"
+        },
+        {
+          id: "v2",
+          lineItemId: "li-2",
+          snapshotId: "snap-old",
+          period: new Date("2025-02-01"),
+          projectedAmount: 2000,
+          actualAmount: 1800,
+          note: "another note",
+          updatedBy: "old-user"
+        }
+      ];
+
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(source);
+      prismaAny.value.findMany.mockResolvedValue(sourceValues);
+
+      const mockValueCreateMany = vi.fn().mockResolvedValue({ count: 2 });
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          snapshot: {
+            create: vi.fn().mockResolvedValue({ id: "snap-new", status: "draft" })
+          },
+          value: { createMany: mockValueCreateMany }
+        };
+        return fn(tx);
+      }) as never;
+      service = new SnapshotService(mockPrisma, mockAudit);
+
+      await service.copyFromPrior({
+        sourceSnapshotId: "snap-old",
+        name: "Q1 2026",
+        asOfMonth: "2026-03",
+        createdBy: "user-1"
+      });
+
+      expect(mockValueCreateMany).toHaveBeenCalledOnce();
+      const valueData = mockValueCreateMany.mock.calls[0][0].data;
+      expect(valueData).toHaveLength(2);
+
+      // Projected amounts ARE copied
+      expect(valueData[0].projectedAmount).toBe(1000);
+      expect(valueData[1].projectedAmount).toBe(2000);
+
+      // Actuals are NOT copied (ADR-003)
+      expect(valueData[0].actualAmount).toBeNull();
+      expect(valueData[1].actualAmount).toBeNull();
+
+      // Notes are NOT copied
+      expect(valueData[0].note).toBeNull();
+      expect(valueData[1].note).toBeNull();
+    });
+
+    it("skips value copy when source has no values", async () => {
+      const source = { id: "snap-old", status: "locked" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(source);
+      prismaAny.value.findMany.mockResolvedValue([]);
+
+      const mockValueCreateMany = vi.fn();
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          snapshot: {
+            create: vi.fn().mockResolvedValue({ id: "snap-new", status: "draft" })
+          },
+          value: { createMany: mockValueCreateMany }
+        };
+        return fn(tx);
+      }) as never;
+      service = new SnapshotService(mockPrisma, mockAudit);
+
+      await service.copyFromPrior({
+        sourceSnapshotId: "snap-old",
+        name: "Q1 2026",
+        asOfMonth: "2026-03",
+        createdBy: "user-1"
+      });
+
+      expect(mockValueCreateMany).not.toHaveBeenCalled();
+    });
+
+    it("logs creation with copiedFrom reference", async () => {
+      const source = { id: "snap-old", status: "locked" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(source);
+      prismaAny.value.findMany.mockResolvedValue([]);
+      prismaAny.$transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          snapshot: {
+            create: vi.fn().mockResolvedValue({ id: "snap-new", status: "draft" })
+          },
+          value: { createMany: vi.fn() }
+        };
+        return fn(tx);
+      }) as never;
+      service = new SnapshotService(mockPrisma, mockAudit);
+
+      await service.copyFromPrior({
+        sourceSnapshotId: "snap-old",
+        name: "Q1 2026",
+        asOfMonth: "2026-03",
+        createdBy: "user-1"
+      });
+
+      const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+      expect(auditAny.logCreate).toHaveBeenCalledOnce();
+      const auditCall = auditAny.logCreate.mock.calls[0][0];
+      expect(auditCall.fields.copiedFrom).toBe("snap-old");
+      expect(auditCall.fields.status).toBe("draft");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // list
+  // -------------------------------------------------------------------------
+  describe("list", () => {
+    it("returns snapshots ordered by createdAt desc", async () => {
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findMany.mockResolvedValue([
+        { id: "snap-2", name: "Q2" },
+        { id: "snap-1", name: "Q1" }
+      ]);
+
+      const result = await service.list();
+
+      expect(result).toHaveLength(2);
+      expect(prismaAny.snapshot.findMany).toHaveBeenCalledWith({
+        orderBy: { createdAt: "desc" },
+        include: {
+          creator: { select: { id: true, name: true, email: true } },
+          locker: { select: { id: true, name: true, email: true } }
+        }
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getById
+  // -------------------------------------------------------------------------
+  describe("getById", () => {
+    it("returns snapshot with relations", async () => {
+      const snapshot = { id: "snap-1", name: "Q1 2026", status: "draft" };
+      const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+      prismaAny.snapshot.findUniqueOrThrow.mockResolvedValue(snapshot);
+
+      const result = await service.getById("snap-1");
+
+      expect(result.id).toBe("snap-1");
+      expect(prismaAny.snapshot.findUniqueOrThrow).toHaveBeenCalledWith({
+        where: { id: "snap-1" },
+        include: {
+          creator: { select: { id: true, name: true, email: true } },
+          locker: { select: { id: true, name: true, email: true } },
+          structureVersion: true
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `SnapshotService` with full lifecycle: create draft, lock (with StructureVersion), unlock, and copy-from-prior
- Copy operation transfers projected values only — actuals start fresh per ADR-003
- Lock creates a `StructureVersion` to capture report shape for reproducibility
- All mutations are audit-logged via `AuditService` integration
- 20 unit tests covering create, lock, unlock, copy, list, getById, and edge cases (already locked, already unlocked, source not locked, empty values)

Closes #6

## Files
- `lib/snapshots/types.ts` — input interfaces + `parseAsOfMonth` utility
- `lib/snapshots/snapshot-service.ts` — service class with Prisma + AuditService
- `lib/snapshots/index.ts` — barrel export
- `tests/unit/snapshot-service.test.ts` — 20 tests

## Test plan
- [x] All 73 tests pass (20 new + 53 existing)
- [x] TypeScript strict mode — no errors
- [x] ESLint — no warnings
- [x] Prettier — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)