### PR TITLE
feat: group management + snapshot handlers + infra fixes

### DIFF
--- a/app/api/groups/[groupId]/route.ts
+++ b/app/api/groups/[groupId]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { archiveGroup, getGroup, updateGroup } from "@/lib/groups/http-handlers";
+import { groupService } from "@/lib/groups/service-factory";
+
+export async function GET(_request: Request, { params }: { params: { groupId: string } }) {
+  const result = await getGroup(groupService, params.groupId);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function PATCH(request: Request, { params }: { params: { groupId: string } }) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const payload = {
+    ...(typeof body === "object" && body ? body : {}),
+    groupId: params.groupId
+  };
+
+  const result = await updateGroup(groupService, payload);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function DELETE(request: Request, { params }: { params: { groupId: string } }) {
+  let body: unknown = {};
+
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const payload = {
+    ...(typeof body === "object" && body ? body : {}),
+    groupId: params.groupId
+  };
+
+  const result = await archiveGroup(groupService, payload);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { createGroup, listGroups } from "@/lib/groups/http-handlers";
+import { groupService } from "@/lib/groups/service-factory";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const includeInactive = url.searchParams.get("includeInactive") === "true";
+
+  const result = await listGroups(groupService, includeInactive);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createGroup(groupService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/snapshots/[snapshotId]/route.ts
+++ b/app/api/snapshots/[snapshotId]/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { getSnapshot } from "@/lib/snapshots/http-handlers";
+import { snapshotService } from "@/lib/snapshots/service-factory";
+
+export async function GET(_request: Request, { params }: { params: { snapshotId: string } }) {
+  const result = await getSnapshot(snapshotService, params.snapshotId);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/snapshots/copy/route.ts
+++ b/app/api/snapshots/copy/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { copySnapshot } from "@/lib/snapshots/http-handlers";
+import { snapshotService } from "@/lib/snapshots/service-factory";
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await copySnapshot(snapshotService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/snapshots/lock/route.ts
+++ b/app/api/snapshots/lock/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { lockSnapshot } from "@/lib/snapshots/http-handlers";
+import { snapshotService } from "@/lib/snapshots/service-factory";
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await lockSnapshot(snapshotService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/snapshots/route.ts
+++ b/app/api/snapshots/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { createSnapshot, listSnapshots } from "@/lib/snapshots/http-handlers";
+import { snapshotService } from "@/lib/snapshots/service-factory";
+
+export async function GET() {
+  const result = await listSnapshots(snapshotService);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createSnapshot(snapshotService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/snapshots/unlock/route.ts
+++ b/app/api/snapshots/unlock/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { unlockSnapshot } from "@/lib/snapshots/http-handlers";
+import { snapshotService } from "@/lib/snapshots/service-factory";
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await unlockSnapshot(snapshotService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "warn", "error"] : ["error"]
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/lib/groups/group-service.ts
+++ b/lib/groups/group-service.ts
@@ -1,0 +1,112 @@
+import type { PrismaClient } from "@prisma/client";
+import { diffFields, type AuditService } from "../audit";
+import type { ArchiveGroupInput, CreateGroupInput, GroupType, UpdateGroupInput } from "./types";
+
+const TRACKED_GROUP_FIELDS = ["name", "groupType", "sortOrder", "isActive", "archivedAt"];
+
+function isGroupType(value: unknown): value is GroupType {
+  return value === "sector" || value === "non_operating" || value === "custom";
+}
+
+export class GroupService {
+  constructor(
+    private prisma: PrismaClient,
+    private audit: AuditService
+  ) {}
+
+  async list(includeInactive = false) {
+    return this.prisma.group.findMany({
+      where: includeInactive ? {} : { isActive: true },
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }]
+    });
+  }
+
+  async getById(groupId: string) {
+    return this.prisma.group.findUniqueOrThrow({ where: { id: groupId } });
+  }
+
+  async create(input: CreateGroupInput) {
+    if (!isGroupType(input.groupType)) {
+      throw new Error("Invalid groupType");
+    }
+
+    const created = await this.prisma.group.create({
+      data: {
+        name: input.name,
+        groupType: input.groupType,
+        sortOrder: input.sortOrder ?? 0,
+        createdBy: input.createdBy
+      }
+    });
+
+    await this.audit.logCreate({
+      userId: input.createdBy,
+      tableName: "Group",
+      recordId: created.id,
+      fields: {
+        name: created.name,
+        groupType: created.groupType,
+        sortOrder: String(created.sortOrder),
+        isActive: String(created.isActive)
+      },
+      source: "ui_edit"
+    });
+
+    return created;
+  }
+
+  async update(input: UpdateGroupInput) {
+    const current = await this.prisma.group.findUniqueOrThrow({ where: { id: input.groupId } });
+
+    if (input.groupType !== undefined && !isGroupType(input.groupType)) {
+      throw new Error("Invalid groupType");
+    }
+
+    const updated = await this.prisma.group.update({
+      where: { id: input.groupId },
+      data: {
+        name: input.name ?? undefined,
+        groupType: input.groupType ?? undefined,
+        sortOrder: input.sortOrder ?? undefined
+      }
+    });
+
+    const changes = diffFields(current, updated, TRACKED_GROUP_FIELDS);
+    await this.audit.logUpdate({
+      userId: input.updatedBy,
+      tableName: "Group",
+      recordId: current.id,
+      changes,
+      reason: input.reason,
+      source: "ui_edit"
+    });
+
+    return updated;
+  }
+
+  async archive(input: ArchiveGroupInput) {
+    const current = await this.prisma.group.findUniqueOrThrow({ where: { id: input.groupId } });
+
+    if (!current.isActive) {
+      throw new Error("Group is already archived");
+    }
+
+    const updated = await this.prisma.group.update({
+      where: { id: input.groupId },
+      data: {
+        isActive: false,
+        archivedAt: new Date()
+      }
+    });
+
+    await this.audit.logArchive({
+      userId: input.archivedBy,
+      tableName: "Group",
+      recordId: current.id,
+      reason: input.reason,
+      source: "ui_edit"
+    });
+
+    return updated;
+  }
+}

--- a/lib/groups/http-handlers.ts
+++ b/lib/groups/http-handlers.ts
@@ -1,0 +1,213 @@
+import type { ArchiveGroupInput, CreateGroupInput, GroupType, UpdateGroupInput } from "./types";
+
+type HandlerResult = {
+  status: number;
+  body: { data?: unknown; error?: string };
+};
+
+type GroupServiceLike = {
+  list: (includeInactive?: boolean) => Promise<unknown>;
+  getById: (groupId: string) => Promise<unknown>;
+  create: (input: CreateGroupInput) => Promise<unknown>;
+  update: (input: UpdateGroupInput) => Promise<unknown>;
+  archive: (input: ArchiveGroupInput) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalNumber(payload: Record<string, unknown>, field: string): number | undefined {
+  const value = payload[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || Number.isNaN(value)) return undefined;
+  return Math.trunc(value);
+}
+
+function parseGroupType(value: unknown): GroupType | null {
+  if (value === "sector" || value === "non_operating" || value === "custom") {
+    return value;
+  }
+
+  return null;
+}
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return "Unexpected error";
+}
+
+function isNotFound(error: unknown): boolean {
+  const message = asErrorMessage(error).toLowerCase();
+  return message.includes("not found") || (message.includes("no") && message.includes("found"));
+}
+
+export async function listGroups(
+  service: GroupServiceLike,
+  includeInactive: boolean
+): Promise<HandlerResult> {
+  try {
+    const data = await service.list(includeInactive);
+    return { status: 200, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Failed to list groups" } };
+  }
+}
+
+export async function getGroup(service: GroupServiceLike, groupId: string): Promise<HandlerResult> {
+  if (!groupId || groupId.trim().length === 0) {
+    return { status: 400, body: { error: "groupId is required" } };
+  }
+
+  try {
+    const data = await service.getById(groupId);
+    return { status: 200, body: { data } };
+  } catch (error) {
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Group not found" } };
+    }
+
+    return { status: 500, body: { error: "Failed to fetch group" } };
+  }
+}
+
+export async function createGroup(
+  service: GroupServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const name = getRequiredString(payload, "name");
+  const groupType = parseGroupType(payload.groupType);
+  const sortOrder = getOptionalNumber(payload, "sortOrder");
+  const createdBy = getOptionalString(payload, "createdBy");
+
+  if (!name || !groupType) {
+    return { status: 400, body: { error: "name and groupType are required" } };
+  }
+
+  try {
+    const data = await service.create({
+      name,
+      groupType,
+      sortOrder,
+      createdBy
+    });
+
+    return { status: 201, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (message.includes("Invalid groupType")) {
+      return { status: 400, body: { error: message } };
+    }
+
+    return { status: 500, body: { error: "Failed to create group" } };
+  }
+}
+
+export async function updateGroup(
+  service: GroupServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const groupId = getRequiredString(payload, "groupId");
+  const name = getOptionalString(payload, "name") ?? undefined;
+  const groupType = payload.groupType === undefined ? undefined : parseGroupType(payload.groupType);
+  const sortOrder = getOptionalNumber(payload, "sortOrder");
+  const updatedBy = getOptionalString(payload, "updatedBy");
+  const reason = getOptionalString(payload, "reason") ?? undefined;
+
+  if (!groupId) {
+    return { status: 400, body: { error: "groupId is required" } };
+  }
+
+  if (groupType === null) {
+    return { status: 400, body: { error: "Invalid groupType" } };
+  }
+
+  if (name === undefined && groupType === undefined && sortOrder === undefined) {
+    return { status: 400, body: { error: "No updatable fields provided" } };
+  }
+
+  try {
+    const data = await service.update({
+      groupId,
+      name,
+      groupType,
+      sortOrder,
+      updatedBy,
+      reason
+    });
+
+    return { status: 200, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Group not found" } };
+    }
+
+    if (message.includes("Invalid groupType")) {
+      return { status: 400, body: { error: message } };
+    }
+
+    return { status: 500, body: { error: "Failed to update group" } };
+  }
+}
+
+export async function archiveGroup(
+  service: GroupServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const groupId = getRequiredString(payload, "groupId");
+  const archivedBy = getOptionalString(payload, "archivedBy");
+  const reason = getOptionalString(payload, "reason") ?? undefined;
+
+  if (!groupId) {
+    return { status: 400, body: { error: "groupId is required" } };
+  }
+
+  try {
+    const data = await service.archive({
+      groupId,
+      archivedBy,
+      reason
+    });
+
+    return { status: 200, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Group not found" } };
+    }
+
+    if (message.includes("already archived")) {
+      return { status: 409, body: { error: message } };
+    }
+
+    return { status: 500, body: { error: "Failed to archive group" } };
+  }
+}

--- a/lib/groups/index.ts
+++ b/lib/groups/index.ts
@@ -1,0 +1,2 @@
+export { GroupService } from "./group-service";
+export type { ArchiveGroupInput, CreateGroupInput, UpdateGroupInput } from "./types";

--- a/lib/groups/service-factory.ts
+++ b/lib/groups/service-factory.ts
@@ -1,0 +1,7 @@
+import { prisma } from "../db";
+import { AuditService } from "../audit";
+import { GroupService } from "./group-service";
+
+const auditService = new AuditService(prisma);
+
+export const groupService = new GroupService(prisma, auditService);

--- a/lib/groups/types.ts
+++ b/lib/groups/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Group types — must stay in sync with GroupType enum in prisma/schema.prisma.
+ * Defined locally so the code compiles before `prisma generate`.
+ */
+export type GroupType = "sector" | "non_operating" | "custom";
+
+export interface CreateGroupInput {
+  name: string;
+  groupType: GroupType;
+  sortOrder?: number;
+  createdBy: string | null;
+}
+
+export interface UpdateGroupInput {
+  groupId: string;
+  name?: string;
+  groupType?: GroupType;
+  sortOrder?: number;
+  updatedBy: string | null;
+  reason?: string;
+}
+
+export interface ArchiveGroupInput {
+  groupId: string;
+  archivedBy: string | null;
+  reason?: string;
+}

--- a/lib/snapshots/http-handlers.ts
+++ b/lib/snapshots/http-handlers.ts
@@ -1,0 +1,206 @@
+import type {
+  CopySnapshotInput,
+  CreateSnapshotInput,
+  LockSnapshotInput,
+  UnlockSnapshotInput
+} from "./types";
+
+type HandlerResult = {
+  status: number;
+  body: { data?: unknown; error?: string };
+};
+
+type SnapshotServiceLike = {
+  list: () => Promise<unknown>;
+  getById: (snapshotId: string) => Promise<unknown>;
+  create: (input: CreateSnapshotInput) => Promise<unknown>;
+  lock: (input: LockSnapshotInput) => Promise<unknown>;
+  unlock: (input: UnlockSnapshotInput) => Promise<unknown>;
+  copyFromPrior: (input: CopySnapshotInput) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isValidAsOfMonth(asOfMonth: string): boolean {
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(asOfMonth);
+}
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return "Unexpected error";
+}
+
+function isNotFound(error: unknown): boolean {
+  const message = asErrorMessage(error).toLowerCase();
+  return message.includes("not found") || (message.includes("no") && message.includes("found"));
+}
+
+export async function listSnapshots(service: SnapshotServiceLike): Promise<HandlerResult> {
+  try {
+    const data = await service.list();
+    return { status: 200, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Failed to list snapshots" } };
+  }
+}
+
+export async function getSnapshot(
+  service: SnapshotServiceLike,
+  snapshotId: string
+): Promise<HandlerResult> {
+  if (!snapshotId || snapshotId.trim().length === 0) {
+    return { status: 400, body: { error: "snapshotId is required" } };
+  }
+
+  try {
+    const data = await service.getById(snapshotId);
+    return { status: 200, body: { data } };
+  } catch (error) {
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Snapshot not found" } };
+    }
+    return { status: 500, body: { error: "Failed to fetch snapshot" } };
+  }
+}
+
+export async function createSnapshot(
+  service: SnapshotServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const name = getRequiredString(payload, "name");
+  const asOfMonth = getRequiredString(payload, "asOfMonth");
+  const createdBy = getRequiredString(payload, "createdBy");
+
+  if (!name || !asOfMonth || !createdBy) {
+    return { status: 400, body: { error: "name, asOfMonth, and createdBy are required" } };
+  }
+
+  if (!isValidAsOfMonth(asOfMonth)) {
+    return { status: 400, body: { error: "asOfMonth must be in YYYY-MM format" } };
+  }
+
+  try {
+    const data = await service.create({ name, asOfMonth, createdBy });
+    return { status: 201, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Failed to create snapshot" } };
+  }
+}
+
+export async function lockSnapshot(
+  service: SnapshotServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const snapshotId = getRequiredString(payload, "snapshotId");
+  const lockedBy = getRequiredString(payload, "lockedBy");
+  const reason = getOptionalString(payload, "reason");
+
+  if (!snapshotId || !lockedBy) {
+    return { status: 400, body: { error: "snapshotId and lockedBy are required" } };
+  }
+
+  try {
+    const data = await service.lock({ snapshotId, lockedBy, reason: reason ?? undefined });
+    return { status: 200, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (message.includes("already locked")) {
+      return { status: 409, body: { error: message } };
+    }
+    return { status: 500, body: { error: "Failed to lock snapshot" } };
+  }
+}
+
+export async function unlockSnapshot(
+  service: SnapshotServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const snapshotId = getRequiredString(payload, "snapshotId");
+  const unlockedBy = getRequiredString(payload, "unlockedBy");
+  const reason = getOptionalString(payload, "reason");
+
+  if (!snapshotId || !unlockedBy) {
+    return { status: 400, body: { error: "snapshotId and unlockedBy are required" } };
+  }
+
+  try {
+    const data = await service.unlock({ snapshotId, unlockedBy, reason: reason ?? undefined });
+    return { status: 200, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (message.includes("already unlocked")) {
+      return { status: 409, body: { error: message } };
+    }
+    return { status: 500, body: { error: "Failed to unlock snapshot" } };
+  }
+}
+
+export async function copySnapshot(
+  service: SnapshotServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const sourceSnapshotId = getRequiredString(payload, "sourceSnapshotId");
+  const name = getRequiredString(payload, "name");
+  const asOfMonth = getRequiredString(payload, "asOfMonth");
+  const createdBy = getRequiredString(payload, "createdBy");
+
+  if (!sourceSnapshotId || !name || !asOfMonth || !createdBy) {
+    return {
+      status: 400,
+      body: { error: "sourceSnapshotId, name, asOfMonth, and createdBy are required" }
+    };
+  }
+
+  if (!isValidAsOfMonth(asOfMonth)) {
+    return { status: 400, body: { error: "asOfMonth must be in YYYY-MM format" } };
+  }
+
+  try {
+    const data = await service.copyFromPrior({
+      sourceSnapshotId,
+      name,
+      asOfMonth,
+      createdBy
+    });
+    return { status: 201, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (message.includes("Can only copy from a locked snapshot")) {
+      return { status: 409, body: { error: message } };
+    }
+    return { status: 500, body: { error: "Failed to copy snapshot" } };
+  }
+}

--- a/lib/snapshots/service-factory.ts
+++ b/lib/snapshots/service-factory.ts
@@ -1,0 +1,7 @@
+import { prisma } from "../db";
+import { AuditService } from "../audit";
+import { SnapshotService } from "./snapshot-service";
+
+const auditService = new AuditService(prisma);
+
+export const snapshotService = new SnapshotService(prisma, auditService);

--- a/lib/snapshots/snapshot-service.ts
+++ b/lib/snapshots/snapshot-service.ts
@@ -16,10 +16,10 @@ import { parseAsOfMonth } from "./types";
 /**
  * Snapshot lifecycle service.
  *
- * Snapshots progress through: draft → locked (→ draft if reopened).
+ * Snapshots progress through: draft -> locked (-> draft if reopened).
  * Locking captures a StructureVersion so the report shape is reproducible.
  * Copying creates a new draft pre-filled with the source's projected values
- * (actuals are NOT copied — per ADR-003 new snapshots start fresh).
+ * (actuals are NOT copied -- per ADR-003 new snapshots start fresh).
  */
 export class SnapshotService {
   constructor(

--- a/lib/validations/group-validation.ts
+++ b/lib/validations/group-validation.ts
@@ -1,0 +1,82 @@
+import type { CreateGroupInput, GroupType, UpdateGroupInput } from "../groups/types";
+
+const VALID_GROUP_TYPES: GroupType[] = ["sector", "non_operating", "custom"];
+const MAX_NAME_LENGTH = 100;
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+/**
+ * Validate input for creating a group.
+ */
+export function validateCreateGroup(input: CreateGroupInput): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!input.name || input.name.trim().length === 0) {
+    errors.push({ field: "name", message: "Name is required" });
+  } else if (input.name.trim().length > MAX_NAME_LENGTH) {
+    errors.push({ field: "name", message: `Name must be ${MAX_NAME_LENGTH} characters or fewer` });
+  }
+
+  if (!input.groupType) {
+    errors.push({ field: "groupType", message: "Group type is required" });
+  } else if (!VALID_GROUP_TYPES.includes(input.groupType)) {
+    errors.push({
+      field: "groupType",
+      message: `Group type must be one of: ${VALID_GROUP_TYPES.join(", ")}`
+    });
+  }
+
+  if (input.sortOrder !== undefined) {
+    if (!Number.isInteger(input.sortOrder) || input.sortOrder < 0) {
+      errors.push({ field: "sortOrder", message: "Sort order must be a non-negative integer" });
+    }
+  }
+
+  if (!input.createdBy || input.createdBy.trim().length === 0) {
+    errors.push({ field: "createdBy", message: "Created by user ID is required" });
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate input for updating a group.
+ */
+export function validateUpdateGroup(input: UpdateGroupInput): ValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!input.groupId || input.groupId.trim().length === 0) {
+    errors.push({ field: "groupId", message: "Group ID is required" });
+  }
+
+  if (input.name !== undefined) {
+    if (input.name.trim().length === 0) {
+      errors.push({ field: "name", message: "Name cannot be empty" });
+    } else if (input.name.trim().length > MAX_NAME_LENGTH) {
+      errors.push({
+        field: "name",
+        message: `Name must be ${MAX_NAME_LENGTH} characters or fewer`
+      });
+    }
+  }
+
+  if (input.sortOrder !== undefined) {
+    if (!Number.isInteger(input.sortOrder) || input.sortOrder < 0) {
+      errors.push({ field: "sortOrder", message: "Sort order must be a non-negative integer" });
+    }
+  }
+
+  if (!input.updatedBy || input.updatedBy.trim().length === 0) {
+    errors.push({ field: "updatedBy", message: "Updated by user ID is required" });
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/lib/validations/index.ts
+++ b/lib/validations/index.ts
@@ -1,0 +1,2 @@
+export { validateCreateGroup, validateUpdateGroup } from "./group-validation";
+export type { ValidationError, ValidationResult } from "./group-validation";

--- a/tests/unit/group-http-handlers.test.ts
+++ b/tests/unit/group-http-handlers.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  archiveGroup,
+  createGroup,
+  getGroup,
+  listGroups,
+  updateGroup
+} from "../../lib/groups/http-handlers";
+
+function createMockService() {
+  return {
+    list: vi.fn().mockResolvedValue([{ id: "grp-1", name: "Rent" }]),
+    getById: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: "grp-new", name: "Other" }),
+    update: vi.fn().mockResolvedValue({ id: "grp-1", name: "Updated" }),
+    archive: vi.fn().mockResolvedValue({ id: "grp-1", isActive: false })
+  };
+}
+
+describe("group HTTP handlers", () => {
+  const mockService = createMockService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists groups", async () => {
+    const result = await listGroups(mockService, false);
+
+    expect(result.status).toBe(200);
+    expect(result.body.data).toEqual([{ id: "grp-1", name: "Rent" }]);
+  });
+
+  it("gets group by id", async () => {
+    mockService.getById.mockResolvedValueOnce({ id: "grp-1" });
+
+    const result = await getGroup(mockService, "grp-1");
+
+    expect(result.status).toBe(200);
+    expect(result.body.data).toEqual({ id: "grp-1" });
+  });
+
+  it("returns 404 when group is not found", async () => {
+    mockService.getById.mockRejectedValueOnce(new Error("No Group found"));
+
+    const result = await getGroup(mockService, "missing");
+
+    expect(result.status).toBe(404);
+    expect(result.body.error).toBe("Group not found");
+  });
+
+  it("creates group with valid payload", async () => {
+    const result = await createGroup(mockService, {
+      name: "Non-Operating",
+      groupType: "non_operating",
+      sortOrder: 3,
+      createdBy: "admin-1"
+    });
+
+    expect(result.status).toBe(201);
+    expect(mockService.create).toHaveBeenCalledWith({
+      name: "Non-Operating",
+      groupType: "non_operating",
+      sortOrder: 3,
+      createdBy: "admin-1"
+    });
+  });
+
+  it("rejects create payload when required fields are missing", async () => {
+    const result = await createGroup(mockService, {
+      name: ""
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("name and groupType are required");
+  });
+
+  it("updates group with valid payload", async () => {
+    const result = await updateGroup(mockService, {
+      groupId: "grp-1",
+      name: "Storage",
+      updatedBy: "admin-1"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.update).toHaveBeenCalledWith({
+      groupId: "grp-1",
+      name: "Storage",
+      groupType: undefined,
+      sortOrder: undefined,
+      updatedBy: "admin-1",
+      reason: undefined
+    });
+  });
+
+  it("rejects update payload when no updatable fields were provided", async () => {
+    const result = await updateGroup(mockService, {
+      groupId: "grp-1",
+      updatedBy: "admin-1"
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("No updatable fields provided");
+  });
+
+  it("archives group", async () => {
+    const result = await archiveGroup(mockService, {
+      groupId: "grp-1",
+      archivedBy: "admin-1",
+      reason: "Consolidated"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.archive).toHaveBeenCalledWith({
+      groupId: "grp-1",
+      archivedBy: "admin-1",
+      reason: "Consolidated"
+    });
+  });
+
+  it("returns 409 when group is already archived", async () => {
+    mockService.archive.mockRejectedValueOnce(new Error("Group is already archived"));
+
+    const result = await archiveGroup(mockService, {
+      groupId: "grp-1",
+      archivedBy: "admin-1"
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toBe("Group is already archived");
+  });
+});

--- a/tests/unit/group-service.test.ts
+++ b/tests/unit/group-service.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GroupService } from "../../lib/groups/group-service";
+
+function createMockAudit() {
+  return {
+    logCreate: vi.fn().mockResolvedValue(undefined),
+    logUpdate: vi.fn().mockResolvedValue(undefined),
+    logArchive: vi.fn().mockResolvedValue(undefined)
+  } as never;
+}
+
+function createMockPrisma() {
+  return {
+    group: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUniqueOrThrow: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn()
+    }
+  } as never;
+}
+
+describe("GroupService", () => {
+  let service: GroupService;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+  let mockAudit: ReturnType<typeof createMockAudit>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = createMockPrisma();
+    mockAudit = createMockAudit();
+    service = new GroupService(mockPrisma, mockAudit);
+  });
+
+  it("lists only active groups by default", async () => {
+    await service.list();
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    expect(prismaAny.group.findMany).toHaveBeenCalledWith({
+      where: { isActive: true },
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }]
+    });
+  });
+
+  it("creates group and logs audit create entries", async () => {
+    const created = {
+      id: "grp-1",
+      name: "Rent",
+      groupType: "sector",
+      sortOrder: 1,
+      isActive: true
+    };
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.group.create.mockResolvedValue(created);
+
+    const result = await service.create({
+      name: "Rent",
+      groupType: "sector",
+      sortOrder: 1,
+      createdBy: "admin-1"
+    });
+
+    expect(result.id).toBe("grp-1");
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logCreate).toHaveBeenCalledOnce();
+  });
+
+  it("updates group and logs field-level changes", async () => {
+    const current = {
+      id: "grp-1",
+      name: "Rent",
+      groupType: "sector",
+      sortOrder: 1,
+      isActive: true,
+      archivedAt: null
+    };
+    const updated = {
+      ...current,
+      name: "Rental Income",
+      sortOrder: 2
+    };
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.group.findUniqueOrThrow.mockResolvedValue(current);
+    prismaAny.group.update.mockResolvedValue(updated);
+
+    await service.update({
+      groupId: "grp-1",
+      name: "Rental Income",
+      sortOrder: 2,
+      updatedBy: "admin-1",
+      reason: "Reordered"
+    });
+
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logUpdate).toHaveBeenCalledOnce();
+    const changes = auditAny.logUpdate.mock.calls[0][0].changes;
+    expect(changes.some((c: { field: string }) => c.field === "name")).toBe(true);
+    expect(changes.some((c: { field: string }) => c.field === "sortOrder")).toBe(true);
+  });
+
+  it("archives group and logs archive event", async () => {
+    const current = {
+      id: "grp-1",
+      isActive: true
+    };
+    const updated = {
+      id: "grp-1",
+      isActive: false,
+      archivedAt: new Date()
+    };
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.group.findUniqueOrThrow.mockResolvedValue(current);
+    prismaAny.group.update.mockResolvedValue(updated);
+
+    const result = await service.archive({
+      groupId: "grp-1",
+      archivedBy: "admin-1",
+      reason: "Deprecated"
+    });
+
+    expect(result.isActive).toBe(false);
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logArchive).toHaveBeenCalledOnce();
+  });
+
+  it("throws when trying to archive an already archived group", async () => {
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.group.findUniqueOrThrow.mockResolvedValue({ id: "grp-1", isActive: false });
+
+    await expect(service.archive({ groupId: "grp-1", archivedBy: "admin-1" })).rejects.toThrow(
+      "Group is already archived"
+    );
+  });
+});

--- a/tests/unit/group-validation.test.ts
+++ b/tests/unit/group-validation.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { validateCreateGroup, validateUpdateGroup } from "../../lib/validations/group-validation";
+
+describe("validateCreateGroup", () => {
+  const valid = { name: "Self Storage", groupType: "sector" as const, createdBy: "user-1" };
+
+  it("passes with valid input", () => {
+    expect(validateCreateGroup(valid).valid).toBe(true);
+  });
+
+  it("passes with optional sortOrder", () => {
+    expect(validateCreateGroup({ ...valid, sortOrder: 3 }).valid).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = validateCreateGroup({ ...valid, name: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  it("rejects whitespace-only name", () => {
+    const result = validateCreateGroup({ ...valid, name: "   " });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  it("rejects name over 100 characters", () => {
+    const result = validateCreateGroup({ ...valid, name: "x".repeat(101) });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  it("accepts name at exactly 100 characters", () => {
+    expect(validateCreateGroup({ ...valid, name: "x".repeat(100) }).valid).toBe(true);
+  });
+
+  it("rejects invalid groupType", () => {
+    const result = validateCreateGroup({ ...valid, groupType: "invalid" as never });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("groupType");
+  });
+
+  it("accepts all valid group types", () => {
+    for (const type of ["sector", "non_operating", "custom"] as const) {
+      expect(validateCreateGroup({ ...valid, groupType: type }).valid).toBe(true);
+    }
+  });
+
+  it("rejects negative sortOrder", () => {
+    const result = validateCreateGroup({ ...valid, sortOrder: -1 });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("sortOrder");
+  });
+
+  it("rejects fractional sortOrder", () => {
+    const result = validateCreateGroup({ ...valid, sortOrder: 1.5 });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("sortOrder");
+  });
+
+  it("rejects empty createdBy", () => {
+    const result = validateCreateGroup({ ...valid, createdBy: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("createdBy");
+  });
+
+  it("collects multiple errors", () => {
+    const result = validateCreateGroup({
+      name: "",
+      groupType: "invalid" as never,
+      createdBy: ""
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("validateUpdateGroup", () => {
+  const valid = { groupId: "grp-1", updatedBy: "user-1" };
+
+  it("passes with no optional fields", () => {
+    expect(validateUpdateGroup(valid).valid).toBe(true);
+  });
+
+  it("passes with name update", () => {
+    expect(validateUpdateGroup({ ...valid, name: "New Name" }).valid).toBe(true);
+  });
+
+  it("passes with sortOrder update", () => {
+    expect(validateUpdateGroup({ ...valid, sortOrder: 5 }).valid).toBe(true);
+  });
+
+  it("rejects empty groupId", () => {
+    const result = validateUpdateGroup({ ...valid, groupId: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("groupId");
+  });
+
+  it("rejects empty name when provided", () => {
+    const result = validateUpdateGroup({ ...valid, name: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("name");
+  });
+
+  it("rejects name over 100 characters", () => {
+    const result = validateUpdateGroup({ ...valid, name: "x".repeat(101) });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects negative sortOrder", () => {
+    const result = validateUpdateGroup({ ...valid, sortOrder: -1 });
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects empty updatedBy", () => {
+    const result = validateUpdateGroup({ ...valid, updatedBy: "" });
+    expect(result.valid).toBe(false);
+    expect(result.errors[0].field).toBe("updatedBy");
+  });
+});

--- a/tests/unit/snapshot-http-handlers.test.ts
+++ b/tests/unit/snapshot-http-handlers.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  copySnapshot,
+  createSnapshot,
+  getSnapshot,
+  listSnapshots,
+  lockSnapshot,
+  unlockSnapshot
+} from "../../lib/snapshots/http-handlers";
+
+function createMockService() {
+  return {
+    list: vi.fn().mockResolvedValue([{ id: "snap-1" }]),
+    getById: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: "snap-new" }),
+    lock: vi.fn().mockResolvedValue({ id: "snap-1", status: "locked" }),
+    unlock: vi.fn().mockResolvedValue({ id: "snap-1", status: "draft" }),
+    copyFromPrior: vi.fn().mockResolvedValue({ id: "snap-copy" })
+  };
+}
+
+describe("snapshot HTTP handlers", () => {
+  const mockService = createMockService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists snapshots", async () => {
+    const result = await listSnapshots(mockService);
+
+    expect(result.status).toBe(200);
+    expect(result.body.data).toEqual([{ id: "snap-1" }]);
+  });
+
+  it("gets snapshot by id", async () => {
+    mockService.getById.mockResolvedValueOnce({ id: "snap-1" });
+
+    const result = await getSnapshot(mockService, "snap-1");
+
+    expect(result.status).toBe(200);
+    expect(result.body.data).toEqual({ id: "snap-1" });
+  });
+
+  it("returns 404 when snapshot is not found", async () => {
+    mockService.getById.mockRejectedValueOnce(new Error("No Snapshot found"));
+
+    const result = await getSnapshot(mockService, "missing");
+
+    expect(result.status).toBe(404);
+    expect(result.body.error).toBe("Snapshot not found");
+  });
+
+  it("creates snapshot with valid payload", async () => {
+    const payload = {
+      name: "March 2026",
+      asOfMonth: "2026-03",
+      createdBy: "user-1"
+    };
+
+    const result = await createSnapshot(mockService, payload);
+
+    expect(result.status).toBe(201);
+    expect(mockService.create).toHaveBeenCalledWith(payload);
+  });
+
+  it("rejects create payload with invalid month format", async () => {
+    const payload = {
+      name: "March 2026",
+      asOfMonth: "2026/03",
+      createdBy: "user-1"
+    };
+
+    const result = await createSnapshot(mockService, payload);
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("asOfMonth must be in YYYY-MM format");
+  });
+
+  it("locks snapshot with valid payload", async () => {
+    const result = await lockSnapshot(mockService, {
+      snapshotId: "snap-1",
+      lockedBy: "admin-1",
+      reason: "Month end"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.lock).toHaveBeenCalledWith({
+      snapshotId: "snap-1",
+      lockedBy: "admin-1",
+      reason: "Month end"
+    });
+  });
+
+  it("returns 409 if snapshot is already locked", async () => {
+    mockService.lock.mockRejectedValueOnce(new Error("Snapshot is already locked"));
+
+    const result = await lockSnapshot(mockService, {
+      snapshotId: "snap-1",
+      lockedBy: "admin-1"
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toBe("Snapshot is already locked");
+  });
+
+  it("unlocks snapshot with valid payload", async () => {
+    const result = await unlockSnapshot(mockService, {
+      snapshotId: "snap-1",
+      unlockedBy: "admin-1",
+      reason: "Correction needed"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.unlock).toHaveBeenCalledWith({
+      snapshotId: "snap-1",
+      unlockedBy: "admin-1",
+      reason: "Correction needed"
+    });
+  });
+
+  it("returns 409 if snapshot is already unlocked", async () => {
+    mockService.unlock.mockRejectedValueOnce(new Error("Snapshot is already unlocked"));
+
+    const result = await unlockSnapshot(mockService, {
+      snapshotId: "snap-1",
+      unlockedBy: "admin-1"
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toBe("Snapshot is already unlocked");
+  });
+
+  it("copies snapshot from locked source", async () => {
+    const payload = {
+      sourceSnapshotId: "snap-locked",
+      name: "Q2 2026",
+      asOfMonth: "2026-04",
+      createdBy: "user-1"
+    };
+
+    const result = await copySnapshot(mockService, payload);
+
+    expect(result.status).toBe(201);
+    expect(mockService.copyFromPrior).toHaveBeenCalledWith(payload);
+  });
+
+  it("returns 409 if copy source snapshot is not locked", async () => {
+    mockService.copyFromPrior.mockRejectedValueOnce(
+      new Error("Can only copy from a locked snapshot")
+    );
+
+    const result = await copySnapshot(mockService, {
+      sourceSnapshotId: "snap-draft",
+      name: "Q2 2026",
+      asOfMonth: "2026-04",
+      createdBy: "user-1"
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toBe("Can only copy from a locked snapshot");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, ".")
+    }
+  },
   test: {
     include: ["tests/**/*.test.ts"],
     environment: "node",


### PR DESCRIPTION
## Summary
- **GroupService** with create, update, archive (soft-delete per ADR-002), list, and getById
- **Input validation** module (`lib/validations/`) with structured error responses for group operations
- **HTTP handler layer** for both groups and snapshots with proper status codes (400/404/409/500)
- **API routes** for groups (`/api/groups`, `/api/groups/[groupId]`) and snapshots (`/api/snapshots`, lock/unlock/copy)
- **Snapshot service** with full lifecycle (also in PR #14 — this branch includes it for API route compilation)
- **Prisma singleton** (`lib/db.ts`) and service factory pattern
- **Fixed `@/` path alias** in `vitest.config.ts` — Codex's imports used `@/lib/audit` which Vitest couldn't resolve
- **Fixed `GroupType` import** — changed from `@prisma/client` (requires `prisma generate`) to local type definition

Joint work: Claude (service layer, validation, type fixes, vitest config) + Codex (HTTP handlers, API routes, service factories)

Closes #3

## Test plan
- [x] 98 tests pass (34 new + 64 existing) across 7 test files
- [x] TypeScript strict mode — zero errors
- [x] ESLint — no warnings
- [x] Prettier — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)