### PR TITLE
feat: data grid UI with monthly entry for desktop and mobile (#7)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,24 @@
+"use client";
+
+import { SnapshotList } from "@/components/SnapshotList";
+
 export default function HomePage() {
   return (
-    <main className="container">
-      <h1>Cash Flow Projection</h1>
-      <p>Project scaffold is initialized and ready for feature development.</p>
+    <main className="dashboard-shell">
+      <div className="dashboard-header">
+        <p className="eyebrow">Sukut Properties</p>
+        <h1>Cash Flow Projection</h1>
+        <p className="subhead">
+          Select a snapshot to view or edit monthly cash flow projections and actuals.
+        </p>
+      </div>
+
+      <section className="snapshot-section">
+        <div className="panel-head">
+          <h2>Snapshots</h2>
+        </div>
+        <SnapshotList />
+      </section>
     </main>
   );
 }

--- a/app/snapshots/[snapshotId]/page.tsx
+++ b/app/snapshots/[snapshotId]/page.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useCallback } from "react";
+import { DataGridView } from "@/components/data-grid";
+import type { PendingEdit } from "@/components/data-grid";
+import { useGridData } from "@/lib/hooks/use-grid-data";
+import "@/components/data-grid/data-grid.css";
+
+export default function SnapshotDataEntryPage() {
+  const params = useParams();
+  const router = useRouter();
+  const snapshotId = params.snapshotId as string;
+
+  const { data, loading, error, reload, saveEdits } = useGridData(snapshotId);
+
+  const handleSave = useCallback(
+    async (edits: PendingEdit[]) => {
+      await saveEdits(edits);
+    },
+    [saveEdits]
+  );
+
+  return (
+    <div className="dashboard-shell">
+      <div className="dashboard-header">
+        <button className="ghost-btn" onClick={() => router.push("/")} type="button">
+          &larr; Back
+        </button>
+        {data && (
+          <>
+            <p className="eyebrow">Snapshot</p>
+            <h1>{data.snapshotName}</h1>
+            <p className="subhead">
+              {data.snapshotStatus === "locked" ? "Locked — read only" : "Draft — editable"}
+              {" \u00B7 "}
+              {data.periods.length} months
+              {" \u00B7 "}
+              {data.groups.reduce((sum, g) => sum + g.rows.length, 0)} line items
+            </p>
+          </>
+        )}
+      </div>
+
+      {loading && (
+        <div className="cf-loading">
+          <p>Loading snapshot data...</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="error-banner">
+          <p>{error}</p>
+          <button className="ghost-btn" onClick={reload} type="button">
+            Retry
+          </button>
+        </div>
+      )}
+
+      {data && (
+        <DataGridView
+          data={data}
+          editable={data.snapshotStatus === "draft"}
+          onSave={handleSave}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/SnapshotList.tsx
+++ b/components/SnapshotList.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Snapshot {
+  id: string;
+  name: string;
+  asOfMonth: string;
+  status: "draft" | "locked";
+  createdAt: string;
+  creator?: { name: string; email: string } | null;
+  locker?: { name: string; email: string } | null;
+}
+
+export function SnapshotList() {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    async function fetchSnapshots() {
+      try {
+        const res = await fetch("/api/snapshots");
+        if (!res.ok) throw new Error("Failed to fetch snapshots");
+        const data = await res.json();
+        setSnapshots(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchSnapshots();
+  }, []);
+
+  if (loading) return <p>Loading snapshots...</p>;
+  if (error) return <div className="error-banner"><p>{error}</p></div>;
+  if (snapshots.length === 0) {
+    return (
+      <div className="cf-empty-state">
+        <p>No snapshots yet. Create your first snapshot to get started.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="list-stack">
+      {snapshots.map((s) => {
+        const asOf = formatAsOfMonth(s.asOfMonth);
+        return (
+          <button
+            key={s.id}
+            className="snapshot-row"
+            onClick={() => router.push(`/snapshots/${s.id}`)}
+            type="button"
+          >
+            <span className={`snapshot-chip ${s.status}`}>{s.status}</span>
+            <span className="snapshot-name">{s.name}</span>
+            <span className="snapshot-month">{asOf}</span>
+            <span className="snapshot-month">
+              {new Date(s.createdAt).toLocaleDateString()}
+            </span>
+            <span className="ghost-btn">Open</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatAsOfMonth(raw: string): string {
+  const d = new Date(raw);
+  const months = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+  ];
+  return `${months[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}

--- a/components/data-grid/CashFlowGrid.tsx
+++ b/components/data-grid/CashFlowGrid.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { GridData, GridGroup, GridRow, PendingEdit } from "./types";
+import { formatCurrency, formatPeriodLabel, parseCurrencyInput } from "./types";
+
+interface CashFlowGridProps {
+  data: GridData;
+  /** Whether the user can edit values (false for viewers or locked snapshots). */
+  editable: boolean;
+  /** Callback when a cell value is committed. */
+  onCellChange?: (edit: PendingEdit) => void;
+  /** Which value layer to show: projected, actual, or both. */
+  viewMode: "projected" | "actual" | "variance";
+}
+
+export function CashFlowGrid({ data, editable, onCellChange, viewMode }: CashFlowGridProps) {
+  const isLocked = data.snapshotStatus === "locked";
+  const canEdit = editable && !isLocked;
+
+  return (
+    <div className="cf-grid-wrapper">
+      <div className="cf-grid-scroll">
+        <table className="cf-grid">
+          <thead>
+            <tr>
+              <th className="cf-grid-label-col cf-grid-sticky-col">Line Item</th>
+              {data.periods.map((p) => (
+                <th key={p} className="cf-grid-period-col">
+                  {formatPeriodLabel(p)}
+                </th>
+              ))}
+              <th className="cf-grid-total-col">Total</th>
+            </tr>
+            {viewMode === "variance" && (
+              <tr className="cf-grid-subheader">
+                <th className="cf-grid-sticky-col"></th>
+                {data.periods.map((p) => (
+                  <th key={`sub-${p}`}>
+                    <div className="cf-grid-sublabels">
+                      <span>Proj</span>
+                      <span>Act</span>
+                      <span>Var</span>
+                    </div>
+                  </th>
+                ))}
+                <th>
+                  <div className="cf-grid-sublabels">
+                    <span>Proj</span>
+                    <span>Act</span>
+                    <span>Var</span>
+                  </div>
+                </th>
+              </tr>
+            )}
+          </thead>
+          <tbody>
+            {data.groups.map((group) => (
+              <GroupSection
+                key={group.id}
+                group={group}
+                periods={data.periods}
+                canEdit={canEdit}
+                viewMode={viewMode}
+                onCellChange={onCellChange}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Group Section
+// ---------------------------------------------------------------------------
+interface GroupSectionProps {
+  group: GridGroup;
+  periods: string[];
+  canEdit: boolean;
+  viewMode: string;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+function GroupSection({ group, periods, canEdit, viewMode, onCellChange }: GroupSectionProps) {
+  return (
+    <>
+      <tr className="cf-grid-group-header">
+        <td className="cf-grid-sticky-col" colSpan={1}>
+          <span className="cf-grid-group-name">{group.name}</span>
+          <span className="cf-grid-group-type">{group.groupType.replace("_", " ")}</span>
+        </td>
+        {periods.map((p) => (
+          <td key={p} className="cf-grid-group-cell"></td>
+        ))}
+        <td className="cf-grid-group-cell"></td>
+      </tr>
+      {group.rows.map((row) => (
+        <LineItemRow
+          key={row.lineItemId}
+          row={row}
+          periods={periods}
+          canEdit={canEdit}
+          viewMode={viewMode}
+          onCellChange={onCellChange}
+        />
+      ))}
+      <SubtotalRow group={group} periods={periods} viewMode={viewMode} />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Line Item Row
+// ---------------------------------------------------------------------------
+interface LineItemRowProps {
+  row: GridRow;
+  periods: string[];
+  canEdit: boolean;
+  viewMode: string;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+function LineItemRow({ row, periods, canEdit, viewMode, onCellChange }: LineItemRowProps) {
+  const calcTotal = (field: "projected" | "actual"): number => {
+    let sum = 0;
+    for (const p of periods) {
+      const val = row.values[p]?.[field];
+      if (val !== null && val !== undefined) {
+        sum += parseFloat(val);
+      }
+    }
+    return sum;
+  };
+
+  const projTotal = calcTotal("projected");
+  const actTotal = calcTotal("actual");
+
+  return (
+    <tr className="cf-grid-row">
+      <td className="cf-grid-sticky-col cf-grid-label">
+        <span className="cf-grid-item-label">{row.label}</span>
+        <span className="cf-grid-item-method">{row.projectionMethod.replace(/_/g, " ")}</span>
+      </td>
+      {periods.map((p) => {
+        const cell = row.values[p] ?? { projected: null, actual: null, note: null, dirty: false };
+        return (
+          <GridCell
+            key={p}
+            lineItemId={row.lineItemId}
+            period={p}
+            projected={cell.projected}
+            actual={cell.actual}
+            dirty={cell.dirty}
+            canEdit={canEdit}
+            viewMode={viewMode}
+            onCellChange={onCellChange}
+          />
+        );
+      })}
+      <td className="cf-grid-total-cell">
+        {viewMode === "variance" ? (
+          <div className="cf-grid-variance-cell">
+            <span>{formatCurrency(projTotal.toFixed(2))}</span>
+            <span>{formatCurrency(actTotal.toFixed(2))}</span>
+            <span className={getVarianceClass(projTotal, actTotal)}>
+              {formatCurrency((actTotal - projTotal).toFixed(2))}
+            </span>
+          </div>
+        ) : (
+          <span className="cf-grid-total-value">
+            {formatCurrency(
+              (viewMode === "projected" ? projTotal : actTotal).toFixed(2)
+            )}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Editable Grid Cell
+// ---------------------------------------------------------------------------
+interface GridCellProps {
+  lineItemId: string;
+  period: string;
+  projected: string | null;
+  actual: string | null;
+  dirty: boolean;
+  canEdit: boolean;
+  viewMode: string;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+function GridCell({
+  lineItemId,
+  period,
+  projected,
+  actual,
+  dirty,
+  canEdit,
+  viewMode,
+  onCellChange
+}: GridCellProps) {
+  const [editing, setEditing] = useState<"projected" | "actual" | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startEdit = useCallback(
+    (field: "projected" | "actual") => {
+      if (!canEdit) return;
+      setEditing(field);
+      const current = field === "projected" ? projected : actual;
+      setEditValue(current ?? "");
+      // Focus input after render
+      setTimeout(() => inputRef.current?.focus(), 0);
+    },
+    [canEdit, projected, actual]
+  );
+
+  const commitEdit = useCallback(() => {
+    if (!editing || !onCellChange) return;
+    const parsed = parseCurrencyInput(editValue);
+    const current = editing === "projected" ? projected : actual;
+    // Only emit if value actually changed
+    if (parsed !== current) {
+      onCellChange({ lineItemId, period, field: editing, value: parsed });
+    }
+    setEditing(null);
+  }, [editing, editValue, lineItemId, period, projected, actual, onCellChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        commitEdit();
+      }
+      if (e.key === "Escape") {
+        setEditing(null);
+      }
+    },
+    [commitEdit]
+  );
+
+  const cellClass = `cf-grid-cell${dirty ? " cf-grid-cell-dirty" : ""}`;
+
+  if (viewMode === "variance") {
+    const proj = projected ? parseFloat(projected) : 0;
+    const act = actual ? parseFloat(actual) : 0;
+    const variance = act - proj;
+    return (
+      <td className={cellClass}>
+        <div className="cf-grid-variance-cell">
+          <span
+            className="cf-grid-val cf-grid-val-proj"
+            onDoubleClick={() => startEdit("projected")}
+          >
+            {editing === "projected" ? (
+              <input
+                ref={inputRef}
+                className="cf-grid-input"
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={commitEdit}
+                onKeyDown={handleKeyDown}
+              />
+            ) : (
+              formatCurrency(projected)
+            )}
+          </span>
+          <span
+            className="cf-grid-val cf-grid-val-act"
+            onDoubleClick={() => startEdit("actual")}
+          >
+            {editing === "actual" ? (
+              <input
+                ref={inputRef}
+                className="cf-grid-input"
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onBlur={commitEdit}
+                onKeyDown={handleKeyDown}
+              />
+            ) : (
+              formatCurrency(actual)
+            )}
+          </span>
+          <span className={`cf-grid-val cf-grid-val-var ${getVarianceClass(proj, act)}`}>
+            {formatCurrency(variance.toFixed(2))}
+          </span>
+        </div>
+      </td>
+    );
+  }
+
+  const field = viewMode === "projected" ? "projected" : "actual";
+  const displayValue = field === "projected" ? projected : actual;
+
+  return (
+    <td className={cellClass} onDoubleClick={() => startEdit(field)}>
+      {editing === field ? (
+        <input
+          ref={inputRef}
+          className="cf-grid-input"
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+        />
+      ) : (
+        <span className={`cf-grid-val ${canEdit ? "cf-grid-val-editable" : ""}`}>
+          {formatCurrency(displayValue)}
+        </span>
+      )}
+    </td>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Subtotal Row
+// ---------------------------------------------------------------------------
+interface SubtotalRowProps {
+  group: GridGroup;
+  periods: string[];
+  viewMode: string;
+}
+
+function SubtotalRow({ group, periods, viewMode }: SubtotalRowProps) {
+  const calcGroupTotal = (period: string, field: "projected" | "actual"): number => {
+    let sum = 0;
+    for (const row of group.rows) {
+      const val = row.values[period]?.[field];
+      if (val !== null && val !== undefined) {
+        sum += parseFloat(val);
+      }
+    }
+    return sum;
+  };
+
+  const grandTotal = (field: "projected" | "actual"): number => {
+    let sum = 0;
+    for (const p of periods) {
+      sum += calcGroupTotal(p, field);
+    }
+    return sum;
+  };
+
+  return (
+    <tr className="cf-grid-subtotal">
+      <td className="cf-grid-sticky-col">
+        <span className="cf-grid-subtotal-label">Subtotal: {group.name}</span>
+      </td>
+      {periods.map((p) => {
+        const projSub = calcGroupTotal(p, "projected");
+        const actSub = calcGroupTotal(p, "actual");
+        return (
+          <td key={p} className="cf-grid-subtotal-cell">
+            {viewMode === "variance" ? (
+              <div className="cf-grid-variance-cell">
+                <span>{formatCurrency(projSub.toFixed(2))}</span>
+                <span>{formatCurrency(actSub.toFixed(2))}</span>
+                <span className={getVarianceClass(projSub, actSub)}>
+                  {formatCurrency((actSub - projSub).toFixed(2))}
+                </span>
+              </div>
+            ) : (
+              formatCurrency(
+                (viewMode === "projected" ? projSub : actSub).toFixed(2)
+              )
+            )}
+          </td>
+        );
+      })}
+      <td className="cf-grid-subtotal-cell">
+        {viewMode === "variance" ? (
+          <div className="cf-grid-variance-cell">
+            <span>{formatCurrency(grandTotal("projected").toFixed(2))}</span>
+            <span>{formatCurrency(grandTotal("actual").toFixed(2))}</span>
+            <span className={getVarianceClass(grandTotal("projected"), grandTotal("actual"))}>
+              {formatCurrency((grandTotal("actual") - grandTotal("projected")).toFixed(2))}
+            </span>
+          </div>
+        ) : (
+          formatCurrency(
+            (viewMode === "projected"
+              ? grandTotal("projected")
+              : grandTotal("actual")
+            ).toFixed(2)
+          )
+        )}
+      </td>
+    </tr>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function getVarianceClass(projected: number, actual: number): string {
+  const diff = actual - projected;
+  if (diff > 0) return "cf-grid-var-positive";
+  if (diff < 0) return "cf-grid-var-negative";
+  return "";
+}

--- a/components/data-grid/DataGridView.tsx
+++ b/components/data-grid/DataGridView.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { CashFlowGrid } from "./CashFlowGrid";
+import { MobileCardView } from "./MobileCardView";
+import type { GridData, PendingEdit } from "./types";
+
+interface DataGridViewProps {
+  data: GridData;
+  editable: boolean;
+  onSave?: (edits: PendingEdit[]) => Promise<void>;
+}
+
+/**
+ * Responsive data grid view.
+ * Shows a spreadsheet table on desktop and card-based layout on mobile.
+ * Manages pending edits and save state.
+ */
+export function DataGridView({ data, editable, onSave }: DataGridViewProps) {
+  const [viewMode, setViewMode] = useState<"projected" | "actual" | "variance">("projected");
+  const [pendingEdits, setPendingEdits] = useState<PendingEdit[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [gridData, setGridData] = useState<GridData>(data);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768);
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+
+  // Reset grid data when prop changes
+  useEffect(() => {
+    setGridData(data);
+    setPendingEdits([]);
+  }, [data]);
+
+  const handleCellChange = useCallback((edit: PendingEdit) => {
+    // Optimistically update the grid data
+    setGridData((prev) => {
+      const updated = { ...prev, groups: prev.groups.map((g) => ({
+        ...g,
+        rows: g.rows.map((r) => {
+          if (r.lineItemId !== edit.lineItemId) return r;
+          const cell = r.values[edit.period] ?? { projected: null, actual: null, note: null, dirty: false };
+          return {
+            ...r,
+            values: {
+              ...r.values,
+              [edit.period]: {
+                ...cell,
+                [edit.field]: edit.value,
+                dirty: true
+              }
+            }
+          };
+        })
+      }))};
+      return updated;
+    });
+
+    // Track pending edit (dedup by lineItemId + period + field)
+    setPendingEdits((prev) => {
+      const key = `${edit.lineItemId}:${edit.period}:${edit.field}`;
+      const filtered = prev.filter(
+        (e) => `${e.lineItemId}:${e.period}:${e.field}` !== key
+      );
+      return [...filtered, edit];
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    if (!onSave || pendingEdits.length === 0) return;
+    setSaving(true);
+    try {
+      await onSave(pendingEdits);
+      // Clear dirty flags after successful save
+      setGridData((prev) => ({
+        ...prev,
+        groups: prev.groups.map((g) => ({
+          ...g,
+          rows: g.rows.map((r) => ({
+            ...r,
+            values: Object.fromEntries(
+              Object.entries(r.values).map(([k, v]) => [k, { ...v, dirty: false }])
+            )
+          }))
+        }))
+      }));
+      setPendingEdits([]);
+    } finally {
+      setSaving(false);
+    }
+  }, [onSave, pendingEdits]);
+
+  const isLocked = gridData.snapshotStatus === "locked";
+
+  return (
+    <div className="cf-view">
+      <div className="cf-view-toolbar">
+        <div className="cf-view-modes">
+          <button
+            className={`ghost-btn${viewMode === "projected" ? " cf-view-mode-active" : ""}`}
+            onClick={() => setViewMode("projected")}
+            type="button"
+          >
+            Projected
+          </button>
+          <button
+            className={`ghost-btn${viewMode === "actual" ? " cf-view-mode-active" : ""}`}
+            onClick={() => setViewMode("actual")}
+            type="button"
+          >
+            Actual
+          </button>
+          <button
+            className={`ghost-btn${viewMode === "variance" ? " cf-view-mode-active" : ""}`}
+            onClick={() => setViewMode("variance")}
+            type="button"
+          >
+            Variance
+          </button>
+        </div>
+        <div className="cf-view-actions">
+          {isLocked && (
+            <span className="snapshot-chip locked">Locked</span>
+          )}
+          {editable && !isLocked && (
+            <button
+              onClick={handleSave}
+              disabled={saving || pendingEdits.length === 0}
+              type="button"
+            >
+              {saving ? "Saving..." : `Save (${pendingEdits.length})`}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {isMobile ? (
+        <MobileCardView
+          data={gridData}
+          editable={editable}
+          onCellChange={handleCellChange}
+        />
+      ) : (
+        <CashFlowGrid
+          data={gridData}
+          editable={editable}
+          onCellChange={handleCellChange}
+          viewMode={viewMode}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/data-grid/MobileCardView.tsx
+++ b/components/data-grid/MobileCardView.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import type { GridData, GridGroup, GridRow, PendingEdit } from "./types";
+import { formatCurrency, formatPeriodLabel, parseCurrencyInput } from "./types";
+
+interface MobileCardViewProps {
+  data: GridData;
+  editable: boolean;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+export function MobileCardView({ data, editable, onCellChange }: MobileCardViewProps) {
+  const [expandedItem, setExpandedItem] = useState<string | null>(null);
+  const canEdit = editable && data.snapshotStatus !== "locked";
+
+  return (
+    <div className="cf-mobile">
+      {data.groups.map((group) => (
+        <MobileGroup
+          key={group.id}
+          group={group}
+          periods={data.periods}
+          expandedItem={expandedItem}
+          onToggle={setExpandedItem}
+          canEdit={canEdit}
+          onCellChange={onCellChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface MobileGroupProps {
+  group: GridGroup;
+  periods: string[];
+  expandedItem: string | null;
+  onToggle: (id: string | null) => void;
+  canEdit: boolean;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+function MobileGroup({ group, periods, expandedItem, onToggle, canEdit, onCellChange }: MobileGroupProps) {
+  return (
+    <div className="cf-mobile-group">
+      <div className="cf-mobile-group-header">
+        <span className="cf-mobile-group-name">{group.name}</span>
+        <span className="cf-mobile-group-type">{group.groupType.replace("_", " ")}</span>
+      </div>
+      {group.rows.map((row) => (
+        <MobileItemCard
+          key={row.lineItemId}
+          row={row}
+          periods={periods}
+          expanded={expandedItem === row.lineItemId}
+          onToggle={() =>
+            onToggle(expandedItem === row.lineItemId ? null : row.lineItemId)
+          }
+          canEdit={canEdit}
+          onCellChange={onCellChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface MobileItemCardProps {
+  row: GridRow;
+  periods: string[];
+  expanded: boolean;
+  onToggle: () => void;
+  canEdit: boolean;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+function MobileItemCard({ row, periods, expanded, onToggle, canEdit, onCellChange }: MobileItemCardProps) {
+  const projTotal = periods.reduce((sum, p) => {
+    const val = row.values[p]?.projected;
+    return sum + (val ? parseFloat(val) : 0);
+  }, 0);
+
+  return (
+    <div className={`cf-mobile-card${expanded ? " cf-mobile-card-expanded" : ""}`}>
+      <button className="cf-mobile-card-header" onClick={onToggle} type="button">
+        <span className="cf-mobile-card-label">{row.label}</span>
+        <span className="cf-mobile-card-total">{formatCurrency(projTotal.toFixed(2))}</span>
+        <span className="cf-mobile-card-chevron">{expanded ? "\u25B2" : "\u25BC"}</span>
+      </button>
+      {expanded && (
+        <div className="cf-mobile-card-body">
+          {periods.map((p) => {
+            const cell = row.values[p] ?? { projected: null, actual: null, note: null, dirty: false };
+            return (
+              <MobileMonthRow
+                key={p}
+                period={p}
+                lineItemId={row.lineItemId}
+                projected={cell.projected}
+                actual={cell.actual}
+                canEdit={canEdit}
+                onCellChange={onCellChange}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface MobileMonthRowProps {
+  period: string;
+  lineItemId: string;
+  projected: string | null;
+  actual: string | null;
+  canEdit: boolean;
+  onCellChange?: (edit: PendingEdit) => void;
+}
+
+function MobileMonthRow({ period, lineItemId, projected, actual, canEdit, onCellChange }: MobileMonthRowProps) {
+  const [editingField, setEditingField] = useState<"projected" | "actual" | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const startEdit = useCallback(
+    (field: "projected" | "actual") => {
+      if (!canEdit) return;
+      setEditingField(field);
+      const current = field === "projected" ? projected : actual;
+      setEditValue(current ?? "");
+      setTimeout(() => inputRef.current?.focus(), 0);
+    },
+    [canEdit, projected, actual]
+  );
+
+  const commitEdit = useCallback(() => {
+    if (!editingField || !onCellChange) return;
+    const parsed = parseCurrencyInput(editValue);
+    const current = editingField === "projected" ? projected : actual;
+    if (parsed !== current) {
+      onCellChange({ lineItemId, period, field: editingField, value: parsed });
+    }
+    setEditingField(null);
+  }, [editingField, editValue, lineItemId, period, projected, actual, onCellChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        commitEdit();
+      }
+    },
+    [commitEdit]
+  );
+
+  return (
+    <div className="cf-mobile-month">
+      <span className="cf-mobile-month-label">{formatPeriodLabel(period)}</span>
+      <div className="cf-mobile-month-values">
+        <div className="cf-mobile-field" onClick={() => startEdit("projected")}>
+          <span className="cf-mobile-field-label">Proj</span>
+          {editingField === "projected" ? (
+            <input
+              ref={inputRef}
+              className="cf-mobile-input"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={handleKeyDown}
+              inputMode="decimal"
+            />
+          ) : (
+            <span className={`cf-mobile-field-value${canEdit ? " cf-mobile-editable" : ""}`}>
+              {formatCurrency(projected)}
+            </span>
+          )}
+        </div>
+        <div className="cf-mobile-field" onClick={() => startEdit("actual")}>
+          <span className="cf-mobile-field-label">Act</span>
+          {editingField === "actual" ? (
+            <input
+              ref={inputRef}
+              className="cf-mobile-input"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={handleKeyDown}
+              inputMode="decimal"
+            />
+          ) : (
+            <span className={`cf-mobile-field-value${canEdit ? " cf-mobile-editable" : ""}`}>
+              {formatCurrency(actual)}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/data-grid/data-grid.css
+++ b/components/data-grid/data-grid.css
@@ -1,0 +1,405 @@
+/* -----------------------------------------------------------------------
+   Cash Flow Data Grid — Desktop spreadsheet + Mobile card layout
+   ----------------------------------------------------------------------- */
+
+/* Wrapper & scroll */
+.cf-grid-wrapper {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--card);
+  overflow: hidden;
+}
+
+.cf-grid-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Table */
+.cf-grid {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+  white-space: nowrap;
+}
+
+.cf-grid th,
+.cf-grid td {
+  padding: 0.45rem 0.6rem;
+  text-align: right;
+  border-bottom: 1px solid var(--line);
+}
+
+/* Header */
+.cf-grid thead th {
+  background: #f5f8ff;
+  font-weight: 700;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.cf-grid-subheader th {
+  font-weight: 600;
+  font-size: 0.72rem;
+  padding: 0.2rem 0.6rem;
+}
+
+/* Sticky first column */
+.cf-grid-sticky-col {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: var(--card);
+  text-align: left;
+  min-width: 180px;
+  max-width: 220px;
+}
+
+.cf-grid thead .cf-grid-sticky-col {
+  z-index: 3;
+  background: #f5f8ff;
+}
+
+.cf-grid-label-col {
+  min-width: 180px;
+}
+
+.cf-grid-period-col {
+  min-width: 90px;
+}
+
+.cf-grid-total-col {
+  min-width: 100px;
+  font-weight: 700;
+}
+
+/* Group header row */
+.cf-grid-group-header {
+  background: #edf2ff;
+}
+
+.cf-grid-group-header td {
+  border-bottom: 2px solid var(--primary);
+}
+
+.cf-grid-group-header .cf-grid-sticky-col {
+  background: #edf2ff;
+}
+
+.cf-grid-group-name {
+  font-weight: 700;
+  color: var(--primary-deep);
+  margin-right: 0.5rem;
+}
+
+.cf-grid-group-type {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+}
+
+.cf-grid-group-cell {
+  background: #edf2ff;
+}
+
+/* Line item rows */
+.cf-grid-row:hover {
+  background: #f8faff;
+}
+
+.cf-grid-row:hover .cf-grid-sticky-col {
+  background: #f8faff;
+}
+
+.cf-grid-label {
+  display: flex;
+  flex-direction: column;
+}
+
+.cf-grid-item-label {
+  font-weight: 500;
+}
+
+.cf-grid-item-method {
+  font-size: 0.7rem;
+  color: var(--muted);
+  text-transform: capitalize;
+}
+
+/* Cell values */
+.cf-grid-val {
+  display: block;
+  padding: 0.15rem 0.3rem;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.cf-grid-val-editable {
+  cursor: pointer;
+}
+
+.cf-grid-val-editable:hover {
+  background: #edf2ff;
+}
+
+.cf-grid-cell-dirty .cf-grid-val {
+  background: #fff8e1;
+}
+
+/* Inline edit input */
+.cf-grid-input {
+  width: 80px;
+  padding: 0.15rem 0.3rem;
+  font-size: 0.88rem;
+  text-align: right;
+  border: 2px solid var(--primary);
+  border-radius: 4px;
+  outline: none;
+}
+
+/* Variance view */
+.cf-grid-variance-cell {
+  display: flex;
+  gap: 0.15rem;
+  justify-content: flex-end;
+}
+
+.cf-grid-variance-cell > span {
+  flex: 1;
+  text-align: right;
+  min-width: 55px;
+}
+
+.cf-grid-sublabels {
+  display: flex;
+  gap: 0.15rem;
+  justify-content: flex-end;
+}
+
+.cf-grid-sublabels > span {
+  flex: 1;
+  text-align: right;
+  min-width: 55px;
+}
+
+.cf-grid-var-positive {
+  color: #177137;
+}
+
+.cf-grid-var-negative {
+  color: var(--danger);
+}
+
+/* Subtotal row */
+.cf-grid-subtotal {
+  background: #f9fbff;
+  font-weight: 700;
+}
+
+.cf-grid-subtotal .cf-grid-sticky-col {
+  background: #f9fbff;
+}
+
+.cf-grid-subtotal-label {
+  font-size: 0.84rem;
+  color: var(--primary-deep);
+}
+
+.cf-grid-subtotal-cell {
+  font-weight: 700;
+  border-top: 2px solid var(--line);
+}
+
+/* Total column */
+.cf-grid-total-cell {
+  font-weight: 600;
+  background: #fafbff;
+}
+
+.cf-grid-total-value {
+  font-weight: 700;
+}
+
+/* -----------------------------------------------------------------------
+   View toolbar
+   ----------------------------------------------------------------------- */
+.cf-view-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.8rem 0;
+  gap: 0.75rem;
+}
+
+.cf-view-modes {
+  display: flex;
+  gap: 0.3rem;
+}
+
+.cf-view-mode-active {
+  background: var(--primary) !important;
+  color: #fff !important;
+}
+
+.cf-view-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+/* -----------------------------------------------------------------------
+   Mobile card view
+   ----------------------------------------------------------------------- */
+.cf-mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cf-mobile-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cf-mobile-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.5rem 0;
+  border-bottom: 2px solid var(--primary);
+}
+
+.cf-mobile-group-name {
+  font-weight: 700;
+  color: var(--primary-deep);
+}
+
+.cf-mobile-group-type {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+}
+
+.cf-mobile-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--card);
+  overflow: hidden;
+}
+
+.cf-mobile-card-expanded {
+  border-color: var(--primary);
+}
+
+.cf-mobile-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.8rem;
+  background: transparent;
+  color: var(--ink);
+  width: 100%;
+  text-align: left;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cf-mobile-card-label {
+  flex: 1;
+}
+
+.cf-mobile-card-total {
+  font-weight: 700;
+  color: var(--primary-deep);
+  margin: 0 0.5rem;
+}
+
+.cf-mobile-card-chevron {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.cf-mobile-card-body {
+  border-top: 1px solid var(--line);
+}
+
+.cf-mobile-month {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.8rem;
+  border-bottom: 1px solid #f0f4ff;
+}
+
+.cf-mobile-month:last-child {
+  border-bottom: none;
+}
+
+.cf-mobile-month-label {
+  font-weight: 600;
+  font-size: 0.84rem;
+  color: var(--muted);
+  min-width: 50px;
+}
+
+.cf-mobile-month-values {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.cf-mobile-field {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.1rem;
+  min-width: 70px;
+}
+
+.cf-mobile-field-label {
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.cf-mobile-field-value {
+  font-size: 0.9rem;
+}
+
+.cf-mobile-editable {
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0.1rem 0.3rem;
+}
+
+.cf-mobile-editable:active {
+  background: #edf2ff;
+}
+
+.cf-mobile-input {
+  width: 70px;
+  padding: 0.2rem 0.3rem;
+  font-size: 0.9rem;
+  text-align: right;
+  border: 2px solid var(--primary);
+  border-radius: 4px;
+  outline: none;
+}
+
+/* -----------------------------------------------------------------------
+   Responsive
+   ----------------------------------------------------------------------- */
+@media (max-width: 768px) {
+  .cf-view-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/components/data-grid/index.ts
+++ b/components/data-grid/index.ts
@@ -1,0 +1,15 @@
+export { CashFlowGrid } from "./CashFlowGrid";
+export { DataGridView } from "./DataGridView";
+export { MobileCardView } from "./MobileCardView";
+export type {
+  CellValue,
+  GridData,
+  GridGroup,
+  GridRow,
+  PendingEdit
+} from "./types";
+export {
+  formatCurrency,
+  formatPeriodLabel,
+  parseCurrencyInput
+} from "./types";

--- a/components/data-grid/types.ts
+++ b/components/data-grid/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Client-side types for the data grid UI.
+ * These represent the shape of data after it's been fetched from the API
+ * and restructured for the grid component.
+ */
+
+/** A single cell value in the grid (one line item × one month). */
+export interface CellValue {
+  projected: string | null;
+  actual: string | null;
+  note: string | null;
+  /** True if this cell has been modified since last save. */
+  dirty: boolean;
+}
+
+/** A row in the grid representing one line item. */
+export interface GridRow {
+  lineItemId: string;
+  label: string;
+  projectionMethod: string;
+  groupId: string;
+  /** Values keyed by period string (YYYY-MM). */
+  values: Record<string, CellValue>;
+}
+
+/** A group of rows in the grid. */
+export interface GridGroup {
+  id: string;
+  name: string;
+  groupType: string;
+  sortOrder: number;
+  rows: GridRow[];
+}
+
+/** The full grid data model. */
+export interface GridData {
+  snapshotId: string;
+  snapshotName: string;
+  snapshotStatus: "draft" | "locked";
+  periods: string[];
+  groups: GridGroup[];
+}
+
+/** Pending cell edit to be saved. */
+export interface PendingEdit {
+  lineItemId: string;
+  period: string;
+  field: "projected" | "actual";
+  value: string | null;
+}
+
+/** Month labels for display. */
+export const MONTH_LABELS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+] as const;
+
+/** Format a YYYY-MM period string to a short label like "Jan 27". */
+export function formatPeriodLabel(period: string): string {
+  const [yearStr, monthStr] = period.split("-");
+  const monthIndex = parseInt(monthStr, 10) - 1;
+  const yearShort = yearStr.slice(2);
+  return `${MONTH_LABELS[monthIndex]} ${yearShort}`;
+}
+
+/** Format a number as currency string for display. */
+export function formatCurrency(value: string | null): string {
+  if (value === null || value === "") return "\u2014"; // em-dash
+  const num = parseFloat(value);
+  if (isNaN(num)) return value;
+  if (num < 0) {
+    return `(${Math.abs(num).toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })})`;
+  }
+  return num.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+}
+
+/** Parse a user-entered currency string to a plain number string. */
+export function parseCurrencyInput(input: string): string | null {
+  if (!input || !input.trim()) return null;
+  // Remove currency symbols, commas, spaces
+  let cleaned = input.replace(/[$,\s]/g, "");
+  // Handle parentheses as negative
+  const parenMatch = /^\((.+)\)$/.exec(cleaned);
+  if (parenMatch) {
+    cleaned = `-${parenMatch[1]}`;
+  }
+  const num = parseFloat(cleaned);
+  if (isNaN(num)) return null;
+  return num.toFixed(2);
+}

--- a/lib/hooks/use-grid-data.ts
+++ b/lib/hooks/use-grid-data.ts
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type { GridData, GridGroup, GridRow, PendingEdit } from "@/components/data-grid/types";
+
+interface UseGridDataResult {
+  data: GridData | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => void;
+  saveEdits: (edits: PendingEdit[]) => Promise<void>;
+}
+
+/**
+ * Fetches snapshot data and transforms it into the GridData shape
+ * expected by the data grid components.
+ */
+export function useGridData(snapshotId: string | null): UseGridDataResult {
+  const [data, setData] = useState<GridData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadTrigger, setReloadTrigger] = useState(0);
+
+  const reload = useCallback(() => {
+    setReloadTrigger((n) => n + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!snapshotId) {
+      setData(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchData() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        // Fetch snapshot, groups, and values in parallel
+        const [snapshotRes, groupsRes, valuesRes] = await Promise.all([
+          fetch(`/api/snapshots/${snapshotId}`),
+          fetch("/api/groups"),
+          fetch(`/api/values?snapshotId=${snapshotId}`)
+        ]);
+
+        if (cancelled) return;
+
+        if (!snapshotRes.ok) throw new Error("Failed to fetch snapshot");
+        if (!groupsRes.ok) throw new Error("Failed to fetch groups");
+        if (!valuesRes.ok) throw new Error("Failed to fetch values");
+
+        const snapshot = await snapshotRes.json();
+        const groups = await groupsRes.json();
+        const values = await valuesRes.json();
+
+        if (cancelled) return;
+
+        const gridData = assembleGridData(snapshot, groups, values);
+        setData(gridData);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load data");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [snapshotId, reloadTrigger]);
+
+  const saveEdits = useCallback(
+    async (edits: PendingEdit[]) => {
+      if (!snapshotId || edits.length === 0) return;
+
+      // Group edits by lineItemId + period to merge projected/actual changes
+      const mergedEdits = new Map<
+        string,
+        { lineItemId: string; period: string; projected?: string | null; actual?: string | null }
+      >();
+
+      for (const edit of edits) {
+        const key = `${edit.lineItemId}:${edit.period}`;
+        const existing = mergedEdits.get(key) ?? {
+          lineItemId: edit.lineItemId,
+          period: edit.period
+        };
+        if (edit.field === "projected") {
+          existing.projected = edit.value;
+        } else {
+          existing.actual = edit.value;
+        }
+        mergedEdits.set(key, existing);
+      }
+
+      // Save each edit via the upsert API
+      const promises = Array.from(mergedEdits.values()).map((edit) =>
+        fetch("/api/values/upsert", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            lineItemId: edit.lineItemId,
+            snapshotId,
+            period: edit.period,
+            projectedAmount: edit.projected !== undefined ? edit.projected : undefined,
+            actualAmount: edit.actual !== undefined ? edit.actual : undefined,
+            updatedBy: null // Will be set by auth context when available
+          })
+        })
+      );
+
+      const results = await Promise.all(promises);
+      const failed = results.filter((r) => !r.ok);
+      if (failed.length > 0) {
+        throw new Error(`Failed to save ${failed.length} value(s)`);
+      }
+    },
+    [snapshotId]
+  );
+
+  return { data, loading, error, reload, saveEdits };
+}
+
+// ---------------------------------------------------------------------------
+// Data assembly
+// ---------------------------------------------------------------------------
+
+interface SnapshotResponse {
+  id: string;
+  name: string;
+  asOfMonth: string;
+  status: "draft" | "locked";
+}
+
+interface GroupResponse {
+  id: string;
+  name: string;
+  groupType: string;
+  sortOrder: number;
+  lineItems?: LineItemResponse[];
+}
+
+interface LineItemResponse {
+  id: string;
+  label: string;
+  groupId: string;
+  projectionMethod: string;
+  sortOrder: number;
+}
+
+interface ValueResponse {
+  lineItemId: string;
+  period: string;
+  projectedAmount: string | null;
+  actualAmount: string | null;
+  note: string | null;
+  lineItem?: LineItemResponse;
+}
+
+function assembleGridData(
+  snapshot: SnapshotResponse,
+  groups: GroupResponse[],
+  values: ValueResponse[]
+): GridData {
+  // Determine periods from values, or default to current year
+  const periodSet = new Set<string>();
+  for (const v of values) {
+    const period = extractPeriod(v.period);
+    if (period) periodSet.add(period);
+  }
+
+  // If no values exist yet, generate 12 months for the snapshot year
+  if (periodSet.size === 0) {
+    const year = new Date(snapshot.asOfMonth).getUTCFullYear();
+    for (let m = 1; m <= 12; m++) {
+      periodSet.add(`${year}-${String(m).padStart(2, "0")}`);
+    }
+  }
+
+  const periods = Array.from(periodSet).sort();
+
+  // Build value lookup: lineItemId -> period -> value
+  const valueLookup = new Map<string, Map<string, ValueResponse>>();
+  for (const v of values) {
+    const period = extractPeriod(v.period);
+    if (!period) continue;
+    if (!valueLookup.has(v.lineItemId)) {
+      valueLookup.set(v.lineItemId, new Map());
+    }
+    valueLookup.get(v.lineItemId)!.set(period, v);
+  }
+
+  // Build line items from values (since values include lineItem data)
+  const lineItemsById = new Map<string, LineItemResponse>();
+  for (const v of values) {
+    if (v.lineItem && !lineItemsById.has(v.lineItemId)) {
+      lineItemsById.set(v.lineItemId, v.lineItem);
+    }
+  }
+
+  // Build grid groups
+  const gridGroups: GridGroup[] = groups
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((group) => {
+      // Find line items for this group
+      const groupLineItems = Array.from(lineItemsById.values())
+        .filter((li) => li.groupId === group.id)
+        .sort((a, b) => a.sortOrder - b.sortOrder);
+
+      const rows: GridRow[] = groupLineItems.map((li) => {
+        const itemValues = valueLookup.get(li.id) ?? new Map();
+        const values: GridRow["values"] = {};
+        for (const p of periods) {
+          const v = itemValues.get(p);
+          values[p] = {
+            projected: v?.projectedAmount ?? null,
+            actual: v?.actualAmount ?? null,
+            note: v?.note ?? null,
+            dirty: false
+          };
+        }
+        return {
+          lineItemId: li.id,
+          label: li.label,
+          projectionMethod: li.projectionMethod,
+          groupId: li.groupId,
+          values
+        };
+      });
+
+      return {
+        id: group.id,
+        name: group.name,
+        groupType: group.groupType,
+        sortOrder: group.sortOrder,
+        rows
+      };
+    })
+    .filter((g) => g.rows.length > 0);
+
+  return {
+    snapshotId: snapshot.id,
+    snapshotName: snapshot.name,
+    snapshotStatus: snapshot.status,
+    periods,
+    groups: gridGroups
+  };
+}
+
+/**
+ * Extract a YYYY-MM string from various date formats
+ * (ISO string, Date, or already formatted).
+ */
+function extractPeriod(raw: string | Date): string | null {
+  if (!raw) return null;
+  const str = typeof raw === "string" ? raw : raw.toISOString();
+  // Try YYYY-MM format
+  const shortMatch = /^(\d{4}-\d{2})$/.exec(str);
+  if (shortMatch) return shortMatch[1];
+  // Try ISO format
+  const isoMatch = /^(\d{4})-(\d{2})/.exec(str);
+  if (isoMatch) return `${isoMatch[1]}-${isoMatch[2]}`;
+  return null;
+}

--- a/tests/unit/data-grid.test.ts
+++ b/tests/unit/data-grid.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatCurrency,
+  formatPeriodLabel,
+  parseCurrencyInput
+} from "../../components/data-grid/types";
+
+describe("formatPeriodLabel", () => {
+  it("formats YYYY-MM to short label", () => {
+    expect(formatPeriodLabel("2027-01")).toBe("Jan 27");
+    expect(formatPeriodLabel("2027-06")).toBe("Jun 27");
+    expect(formatPeriodLabel("2027-12")).toBe("Dec 27");
+  });
+
+  it("handles different years", () => {
+    expect(formatPeriodLabel("2030-03")).toBe("Mar 30");
+  });
+});
+
+describe("formatCurrency", () => {
+  it("formats positive numbers with commas", () => {
+    expect(formatCurrency("10000.00")).toBe("10,000");
+    expect(formatCurrency("1234567.89")).toBe("1,234,568");
+  });
+
+  it("formats negative numbers in parentheses", () => {
+    expect(formatCurrency("-5000.00")).toBe("(5,000)");
+    expect(formatCurrency("-123.45")).toBe("(123)");
+  });
+
+  it("returns em-dash for null", () => {
+    expect(formatCurrency(null)).toBe("\u2014");
+  });
+
+  it("returns em-dash for empty string", () => {
+    expect(formatCurrency("")).toBe("\u2014");
+  });
+
+  it("formats zero", () => {
+    expect(formatCurrency("0")).toBe("0");
+    expect(formatCurrency("0.00")).toBe("0");
+  });
+
+  it("handles non-numeric strings", () => {
+    expect(formatCurrency("abc")).toBe("abc");
+  });
+});
+
+describe("parseCurrencyInput", () => {
+  it("parses plain numbers", () => {
+    expect(parseCurrencyInput("10000")).toBe("10000.00");
+    expect(parseCurrencyInput("123.45")).toBe("123.45");
+  });
+
+  it("parses numbers with commas", () => {
+    expect(parseCurrencyInput("10,000")).toBe("10000.00");
+    expect(parseCurrencyInput("1,234,567.89")).toBe("1234567.89");
+  });
+
+  it("parses numbers with dollar sign", () => {
+    expect(parseCurrencyInput("$10000")).toBe("10000.00");
+    expect(parseCurrencyInput("$1,234.56")).toBe("1234.56");
+  });
+
+  it("parses negative values in parentheses", () => {
+    expect(parseCurrencyInput("(5000)")).toBe("-5000.00");
+    expect(parseCurrencyInput("(1,234.56)")).toBe("-1234.56");
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseCurrencyInput("")).toBeNull();
+    expect(parseCurrencyInput("   ")).toBeNull();
+  });
+
+  it("returns null for non-numeric input", () => {
+    expect(parseCurrencyInput("abc")).toBeNull();
+  });
+
+  it("handles whitespace", () => {
+    expect(parseCurrencyInput(" 100 ")).toBe("100.00");
+  });
+});


### PR DESCRIPTION
## Summary
- Custom spreadsheet-like data grid for monthly cash flow entry — no external grid library needed
- **Desktop**: frozen first column, inline double-click cell editing, group headers with subtotals, Total column, three view modes (Projected / Actual / Variance with color-coded deltas)
- **Mobile**: card-based layout with expandable line items and tap-to-edit month entries with decimal keyboard (ADR-004)
- Dashboard home page with snapshot selector for navigation
- `useGridData` hook fetches snapshot + groups + values in parallel, assembles grid data, handles optimistic updates and batch save
- 15 unit tests for grid utility functions

## Components
- `components/data-grid/CashFlowGrid.tsx` — desktop spreadsheet table
- `components/data-grid/MobileCardView.tsx` — mobile card layout
- `components/data-grid/DataGridView.tsx` — responsive wrapper with view mode toggle and save state
- `components/SnapshotList.tsx` — snapshot selector for dashboard
- `app/snapshots/[snapshotId]/page.tsx` — data entry page
- `lib/hooks/use-grid-data.ts` — data fetching and save hook

## Test plan
- [x] 207 tests passing (15 new + 192 existing)
- [x] TypeScript clean (`tsc --noEmit` passes)
- [ ] Visual testing with real data after DB setup
- [ ] Mobile viewport testing
- [ ] Keyboard navigation testing (Tab, Enter, Escape)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)