### PR TITLE
feat: line item CRUD with projection strategy picker (#4)

### DIFF
--- a/app/admin/line-items/page.tsx
+++ b/app/admin/line-items/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { LineItemManager } from "@/components/line-items";
+import "@/components/line-items/line-items.css";
+
+interface Group {
+  id: string;
+  name: string;
+  groupType: string;
+  sortOrder: number;
+}
+
+export default function LineItemsAdminPage() {
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchGroups() {
+      try {
+        const res = await fetch("/api/groups");
+        if (!res.ok) throw new Error("Failed to fetch groups");
+        const data = await res.json();
+        const groupList = data.data ?? data;
+        setGroups(groupList);
+        if (groupList.length > 0 && !selectedGroupId) {
+          setSelectedGroupId(groupList[0].id);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchGroups();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectedGroup = groups.find((g) => g.id === selectedGroupId);
+
+  return (
+    <div className="dashboard-shell">
+      <div className="dashboard-header">
+        <p className="eyebrow">Admin</p>
+        <h1>Line Items</h1>
+        <p className="subhead">
+          Manage line items and configure projection strategies for each group.
+        </p>
+      </div>
+
+      {loading && <p>Loading groups...</p>}
+      {error && (
+        <div className="error-banner">
+          <p>{error}</p>
+        </div>
+      )}
+
+      {!loading && groups.length > 0 && (
+        <div className="grid-layout">
+          {/* Group selector sidebar */}
+          <div className="card panel">
+            <div className="panel-head">
+              <h2>Groups</h2>
+            </div>
+            <div className="list-stack">
+              {groups.map((g) => (
+                <button
+                  key={g.id}
+                  className={`row-card${g.id === selectedGroupId ? " selected" : ""}`}
+                  onClick={() => setSelectedGroupId(g.id)}
+                  type="button"
+                  style={{ cursor: "pointer", textAlign: "left" }}
+                >
+                  <span style={{ fontWeight: 600 }}>{g.name}</span>
+                  <span style={{ fontSize: "0.82rem", color: "var(--muted)" }}>
+                    {g.groupType.replace("_", " ")}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Line item manager */}
+          <div className="card panel">
+            {selectedGroup ? (
+              <LineItemManager
+                groupId={selectedGroup.id}
+                groupName={selectedGroup.name}
+              />
+            ) : (
+              <p>Select a group to manage its line items.</p>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!loading && groups.length === 0 && (
+        <div className="cf-empty-state">
+          <p>No groups yet. Create groups first before adding line items.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/line-items/[lineItemId]/route.ts
+++ b/app/api/line-items/[lineItemId]/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import {
+  archiveLineItem,
+  getLineItem,
+  updateLineItem
+} from "../../../../lib/line-items/http-handlers";
+import { lineItemService } from "../../../../lib/line-items/service-factory";
+
+export async function GET(_request: Request, { params }: { params: { lineItemId: string } }) {
+  const result = await getLineItem(lineItemService, params.lineItemId);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function PATCH(request: Request, { params }: { params: { lineItemId: string } }) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const payload = {
+    ...(typeof body === "object" && body ? body : {}),
+    lineItemId: params.lineItemId
+  };
+
+  const result = await updateLineItem(lineItemService, payload);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function DELETE(request: Request, { params }: { params: { lineItemId: string } }) {
+  let body: unknown = {};
+
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const payload = {
+    ...(typeof body === "object" && body ? body : {}),
+    lineItemId: params.lineItemId
+  };
+
+  const result = await archiveLineItem(lineItemService, payload);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/line-items/route.ts
+++ b/app/api/line-items/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { createLineItem, listLineItems } from "../../../lib/line-items/http-handlers";
+import { lineItemService } from "../../../lib/line-items/service-factory";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const groupId = url.searchParams.get("groupId") ?? undefined;
+  const includeInactive = url.searchParams.get("includeInactive") === "true";
+
+  const result = await listLineItems(lineItemService, groupId, includeInactive);
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await createLineItem(lineItemService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/values/route.ts
+++ b/app/api/values/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { listValues } from "../../../lib/values/http-handlers";
+import { valueService } from "../../../lib/values/service-factory";
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const snapshotId = url.searchParams.get("snapshotId");
+  const groupId = url.searchParams.get("groupId") ?? undefined;
+
+  const result = await listValues(valueService, snapshotId, groupId);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/values/upsert/route.ts
+++ b/app/api/values/upsert/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { upsertValue } from "../../../../lib/values/http-handlers";
+import { valueService } from "../../../../lib/values/service-factory";
+
+export async function POST(request: Request) {
+  let body: unknown;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await upsertValue(valueService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/components/line-items/LineItemManager.tsx
+++ b/components/line-items/LineItemManager.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  ProjectionStrategyPicker,
+  type ProjectionConfig,
+  type ProjectionMethod
+} from "./ProjectionStrategyPicker";
+
+interface LineItem {
+  id: string;
+  groupId: string;
+  label: string;
+  projectionMethod: ProjectionMethod;
+  projectionParams: Record<string, unknown> | null;
+  sortOrder: number;
+  isActive: boolean;
+}
+
+interface LineItemManagerProps {
+  groupId: string;
+  groupName: string;
+}
+
+/**
+ * Line item CRUD management panel for a specific group.
+ * Supports creating, editing projection config, and archiving line items.
+ */
+export function LineItemManager({ groupId, groupName }: LineItemManagerProps) {
+  const [items, setItems] = useState<LineItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  // Create form state
+  const [newLabel, setNewLabel] = useState("");
+  const [newConfig, setNewConfig] = useState<ProjectionConfig>({
+    method: "manual",
+    params: {}
+  });
+  const [creating, setCreating] = useState(false);
+
+  const fetchItems = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/line-items?groupId=${groupId}`);
+      if (!res.ok) throw new Error("Failed to fetch line items");
+      const data = await res.json();
+      setItems(data.data ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [groupId]);
+
+  useEffect(() => {
+    fetchItems();
+  }, [fetchItems]);
+
+  const handleCreate = useCallback(async () => {
+    if (!newLabel.trim()) return;
+    setCreating(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/line-items", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          groupId,
+          label: newLabel.trim(),
+          projectionMethod: newConfig.method,
+          projectionParams: newConfig.params,
+          createdBy: null
+        })
+      });
+
+      if (!res.ok) {
+        const body = await res.json();
+        throw new Error(body.error ?? "Failed to create line item");
+      }
+
+      setNewLabel("");
+      setNewConfig({ method: "manual", params: {} });
+      await fetchItems();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setCreating(false);
+    }
+  }, [groupId, newLabel, newConfig, fetchItems]);
+
+  const handleArchive = useCallback(
+    async (itemId: string) => {
+      setError(null);
+      try {
+        const res = await fetch(`/api/line-items/${itemId}`, {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ archivedBy: null })
+        });
+
+        if (!res.ok) {
+          const body = await res.json();
+          throw new Error(body.error ?? "Failed to archive");
+        }
+
+        await fetchItems();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    },
+    [fetchItems]
+  );
+
+  const handleUpdateProjection = useCallback(
+    async (itemId: string, config: ProjectionConfig) => {
+      setError(null);
+      try {
+        const res = await fetch(`/api/line-items/${itemId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            projectionMethod: config.method,
+            projectionParams: config.params,
+            updatedBy: null
+          })
+        });
+
+        if (!res.ok) {
+          const body = await res.json();
+          throw new Error(body.error ?? "Failed to update");
+        }
+
+        setEditingId(null);
+        await fetchItems();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    },
+    [fetchItems]
+  );
+
+  if (loading) return <p>Loading line items...</p>;
+
+  return (
+    <div className="li-manager">
+      <div className="li-manager-header">
+        <h3>{groupName}</h3>
+        <span className="li-manager-count">{items.length} items</span>
+      </div>
+
+      {error && (
+        <div className="error-banner">
+          <p>{error}</p>
+        </div>
+      )}
+
+      {/* Create form */}
+      <div className="li-create-form">
+        <div className="li-create-row">
+          <input
+            type="text"
+            placeholder="New line item label..."
+            value={newLabel}
+            onChange={(e) => setNewLabel(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+          />
+          <button onClick={handleCreate} disabled={creating || !newLabel.trim()} type="button">
+            {creating ? "Adding..." : "Add"}
+          </button>
+        </div>
+        <ProjectionStrategyPicker
+          value={newConfig}
+          onChange={setNewConfig}
+          disabled={creating}
+        />
+      </div>
+
+      {/* Item list */}
+      <div className="list-stack">
+        {items.map((item) => (
+          <LineItemCard
+            key={item.id}
+            item={item}
+            editing={editingId === item.id}
+            onEdit={() => setEditingId(editingId === item.id ? null : item.id)}
+            onArchive={() => handleArchive(item.id)}
+            onUpdateProjection={(config) => handleUpdateProjection(item.id, config)}
+          />
+        ))}
+        {items.length === 0 && (
+          <p className="li-empty">No line items yet. Add one above.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Line Item Card
+// ---------------------------------------------------------------------------
+
+interface LineItemCardProps {
+  item: LineItem;
+  editing: boolean;
+  onEdit: () => void;
+  onArchive: () => void;
+  onUpdateProjection: (config: ProjectionConfig) => void;
+}
+
+function LineItemCard({ item, editing, onEdit, onArchive, onUpdateProjection }: LineItemCardProps) {
+  const [editConfig, setEditConfig] = useState<ProjectionConfig>({
+    method: item.projectionMethod,
+    params: item.projectionParams ?? {}
+  });
+
+  const methodLabel = {
+    manual: "Manual",
+    annual_spread: "Annual Spread",
+    prior_year_pct: "Prior Year +/- %",
+    prior_year_flat: "Prior Year Flat",
+    custom_formula: "Custom Formula"
+  }[item.projectionMethod];
+
+  return (
+    <div className={`row-card${editing ? " selected" : ""}`}>
+      <span className="li-card-label">{item.label}</span>
+      <span className="li-card-method">{methodLabel}</span>
+      <button className="ghost-btn" onClick={onEdit} type="button">
+        {editing ? "Close" : "Edit"}
+      </button>
+      <button className="danger" onClick={onArchive} type="button">
+        Archive
+      </button>
+      {editing && (
+        <div className="li-card-edit">
+          <ProjectionStrategyPicker
+            value={editConfig}
+            onChange={setEditConfig}
+          />
+          <button
+            onClick={() => onUpdateProjection(editConfig)}
+            type="button"
+          >
+            Save Projection
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/line-items/ProjectionStrategyPicker.tsx
+++ b/components/line-items/ProjectionStrategyPicker.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+export type ProjectionMethod =
+  | "manual"
+  | "annual_spread"
+  | "prior_year_pct"
+  | "prior_year_flat"
+  | "custom_formula";
+
+export interface ProjectionConfig {
+  method: ProjectionMethod;
+  params: Record<string, unknown>;
+}
+
+interface ProjectionStrategyPickerProps {
+  value: ProjectionConfig;
+  onChange: (config: ProjectionConfig) => void;
+  disabled?: boolean;
+}
+
+const METHOD_LABELS: Record<ProjectionMethod, string> = {
+  manual: "Manual Entry",
+  annual_spread: "Annual Spread",
+  prior_year_pct: "Prior Year +/- %",
+  prior_year_flat: "Prior Year Flat",
+  custom_formula: "Custom Formula"
+};
+
+const METHOD_DESCRIPTIONS: Record<ProjectionMethod, string> = {
+  manual: "Enter each month's projection manually.",
+  annual_spread: "Spread an annual total evenly across 12 months.",
+  prior_year_pct: "Apply a percentage change to prior year actuals.",
+  prior_year_flat: "Copy prior year actuals exactly (0% change).",
+  custom_formula: "Define a custom calculation formula."
+};
+
+/**
+ * Projection strategy picker with method-specific parameter inputs.
+ * Used when creating or editing a line item's projection configuration.
+ */
+export function ProjectionStrategyPicker({
+  value,
+  onChange,
+  disabled = false
+}: ProjectionStrategyPickerProps) {
+  const handleMethodChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const method = e.target.value as ProjectionMethod;
+      // Reset params when method changes
+      const defaultParams = getDefaultParams(method);
+      onChange({ method, params: defaultParams });
+    },
+    [onChange]
+  );
+
+  return (
+    <div className="strategy-picker">
+      <div className="strategy-picker-select">
+        <label className="strategy-picker-label" htmlFor="projection-method">
+          Projection Method
+        </label>
+        <select
+          id="projection-method"
+          value={value.method}
+          onChange={handleMethodChange}
+          disabled={disabled}
+        >
+          {Object.entries(METHOD_LABELS).map(([method, label]) => (
+            <option key={method} value={method}>
+              {label}
+            </option>
+          ))}
+        </select>
+        <p className="strategy-picker-desc">{METHOD_DESCRIPTIONS[value.method]}</p>
+      </div>
+
+      <div className="strategy-picker-params">
+        {value.method === "annual_spread" && (
+          <AnnualSpreadParams
+            params={value.params}
+            onChange={(params) => onChange({ method: value.method, params })}
+            disabled={disabled}
+          />
+        )}
+        {value.method === "prior_year_pct" && (
+          <PriorYearPctParams
+            params={value.params}
+            onChange={(params) => onChange({ method: value.method, params })}
+            disabled={disabled}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Parameter Inputs
+// ---------------------------------------------------------------------------
+
+interface ParamProps {
+  params: Record<string, unknown>;
+  onChange: (params: Record<string, unknown>) => void;
+  disabled: boolean;
+}
+
+function AnnualSpreadParams({ params, onChange, disabled }: ParamProps) {
+  const annualTotal = (params.annualTotal as string) ?? "";
+
+  return (
+    <div className="strategy-param">
+      <label className="strategy-param-label" htmlFor="annual-total">
+        Annual Total ($)
+      </label>
+      <input
+        id="annual-total"
+        type="text"
+        inputMode="decimal"
+        placeholder="e.g., 120000"
+        value={annualTotal}
+        onChange={(e) => onChange({ ...params, annualTotal: e.target.value })}
+        disabled={disabled}
+      />
+      {annualTotal && !isNaN(Number(annualTotal.replace(/,/g, ""))) && (
+        <p className="strategy-param-hint">
+          Monthly: ${(Number(annualTotal.replace(/,/g, "")) / 12).toLocaleString("en-US", {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+          })}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PriorYearPctParams({ params, onChange, disabled }: ParamProps) {
+  const [inputValue, setInputValue] = useState(String(params.pctChange ?? ""));
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const raw = e.target.value;
+      setInputValue(raw);
+      const num = parseFloat(raw);
+      if (!isNaN(num)) {
+        onChange({ ...params, pctChange: num });
+      }
+    },
+    [params, onChange]
+  );
+
+  return (
+    <div className="strategy-param">
+      <label className="strategy-param-label" htmlFor="pct-change">
+        Percentage Change (%)
+      </label>
+      <input
+        id="pct-change"
+        type="text"
+        inputMode="decimal"
+        placeholder="e.g., 5 for +5%, -10 for -10%"
+        value={inputValue}
+        onChange={handleChange}
+        disabled={disabled}
+      />
+      {inputValue && !isNaN(Number(inputValue)) && (
+        <p className="strategy-param-hint">
+          {Number(inputValue) >= 0 ? "+" : ""}
+          {Number(inputValue)}% applied to each prior year monthly actual
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getDefaultParams(method: ProjectionMethod): Record<string, unknown> {
+  switch (method) {
+    case "annual_spread":
+      return { annualTotal: "" };
+    case "prior_year_pct":
+      return { pctChange: 0 };
+    default:
+      return {};
+  }
+}

--- a/components/line-items/index.ts
+++ b/components/line-items/index.ts
@@ -1,0 +1,3 @@
+export { LineItemManager } from "./LineItemManager";
+export { ProjectionStrategyPicker } from "./ProjectionStrategyPicker";
+export type { ProjectionConfig, ProjectionMethod } from "./ProjectionStrategyPicker";

--- a/components/line-items/line-items.css
+++ b/components/line-items/line-items.css
@@ -1,0 +1,133 @@
+/* -----------------------------------------------------------------------
+   Line Item Manager & Projection Strategy Picker
+   ----------------------------------------------------------------------- */
+
+.li-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.li-manager-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.li-manager-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.li-manager-count {
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+/* Create form */
+.li-create-form {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #fbfcff;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.li-create-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.li-create-row input {
+  flex: 1;
+}
+
+.li-empty {
+  color: var(--muted);
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+}
+
+/* Line item card */
+.li-card-label {
+  font-weight: 600;
+}
+
+.li-card-method {
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.li-card-edit {
+  grid-column: 1 / -1;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+/* Strategy picker */
+.strategy-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.strategy-picker-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.strategy-picker-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.strategy-picker-desc {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.strategy-picker-params {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.strategy-param {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.strategy-param-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.strategy-param-hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--primary);
+}
+
+/* Responsive */
+@media (max-width: 520px) {
+  .li-create-row {
+    flex-direction: column;
+  }
+
+  .row-card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/lib/line-items/http-handlers.ts
+++ b/lib/line-items/http-handlers.ts
@@ -1,0 +1,247 @@
+import type {
+  ArchiveLineItemInput,
+  CreateLineItemInput,
+  ProjectionMethod,
+  UpdateLineItemInput
+} from "./types";
+
+type HandlerResult = {
+  status: number;
+  body: { data?: unknown; error?: string };
+};
+
+type LineItemServiceLike = {
+  list: (input?: { groupId?: string; includeInactive?: boolean }) => Promise<unknown>;
+  getById: (lineItemId: string) => Promise<unknown>;
+  create: (input: CreateLineItemInput) => Promise<unknown>;
+  update: (input: UpdateLineItemInput) => Promise<unknown>;
+  archive: (input: ArchiveLineItemInput) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalNumber(payload: Record<string, unknown>, field: string): number | undefined {
+  const value = payload[field];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "number" || Number.isNaN(value)) return undefined;
+  return Math.trunc(value);
+}
+
+function parseProjectionMethod(value: unknown): ProjectionMethod | null {
+  if (
+    value === "manual" ||
+    value === "annual_spread" ||
+    value === "prior_year_pct" ||
+    value === "prior_year_flat" ||
+    value === "custom_formula"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  return "Unexpected error";
+}
+
+function isNotFound(error: unknown): boolean {
+  const message = asErrorMessage(error).toLowerCase();
+  return message.includes("not found") || (message.includes("no") && message.includes("found"));
+}
+
+export async function listLineItems(
+  service: LineItemServiceLike,
+  groupId: string | undefined,
+  includeInactive: boolean
+): Promise<HandlerResult> {
+  try {
+    const data = await service.list({ groupId, includeInactive });
+    return { status: 200, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Failed to list line items" } };
+  }
+}
+
+export async function getLineItem(
+  service: LineItemServiceLike,
+  lineItemId: string
+): Promise<HandlerResult> {
+  if (!lineItemId || lineItemId.trim().length === 0) {
+    return { status: 400, body: { error: "lineItemId is required" } };
+  }
+
+  try {
+    const data = await service.getById(lineItemId);
+    return { status: 200, body: { data } };
+  } catch (error) {
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Line item not found" } };
+    }
+
+    return { status: 500, body: { error: "Failed to fetch line item" } };
+  }
+}
+
+export async function createLineItem(
+  service: LineItemServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const groupId = getRequiredString(payload, "groupId");
+  const label = getRequiredString(payload, "label");
+  const projectionMethod =
+    payload.projectionMethod === undefined
+      ? undefined
+      : parseProjectionMethod(payload.projectionMethod);
+  const projectionParams = payload.projectionParams;
+  const sortOrder = getOptionalNumber(payload, "sortOrder");
+  const createdBy = getOptionalString(payload, "createdBy");
+
+  if (!groupId || !label) {
+    return { status: 400, body: { error: "groupId and label are required" } };
+  }
+
+  if (projectionMethod === null) {
+    return { status: 400, body: { error: "Invalid projectionMethod" } };
+  }
+
+  try {
+    const data = await service.create({
+      groupId,
+      label,
+      projectionMethod,
+      projectionParams,
+      sortOrder,
+      createdBy
+    });
+
+    return { status: 201, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (message.includes("Invalid projectionMethod")) {
+      return { status: 400, body: { error: message } };
+    }
+
+    return { status: 500, body: { error: "Failed to create line item" } };
+  }
+}
+
+export async function updateLineItem(
+  service: LineItemServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const lineItemId = getRequiredString(payload, "lineItemId");
+  const groupId = getOptionalString(payload, "groupId") ?? undefined;
+  const label = getOptionalString(payload, "label") ?? undefined;
+  const projectionMethod =
+    payload.projectionMethod === undefined
+      ? undefined
+      : parseProjectionMethod(payload.projectionMethod);
+  const projectionParams = payload.projectionParams;
+  const sortOrder = getOptionalNumber(payload, "sortOrder");
+  const updatedBy = getOptionalString(payload, "updatedBy");
+  const reason = getOptionalString(payload, "reason") ?? undefined;
+
+  if (!lineItemId) {
+    return { status: 400, body: { error: "lineItemId is required" } };
+  }
+
+  if (projectionMethod === null) {
+    return { status: 400, body: { error: "Invalid projectionMethod" } };
+  }
+
+  if (
+    groupId === undefined &&
+    label === undefined &&
+    projectionMethod === undefined &&
+    payload.projectionParams === undefined &&
+    sortOrder === undefined
+  ) {
+    return { status: 400, body: { error: "No updatable fields provided" } };
+  }
+
+  try {
+    const data = await service.update({
+      lineItemId,
+      groupId,
+      label,
+      projectionMethod,
+      projectionParams,
+      sortOrder,
+      updatedBy,
+      reason
+    });
+
+    return { status: 200, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Line item not found" } };
+    }
+
+    if (message.includes("Invalid projectionMethod")) {
+      return { status: 400, body: { error: message } };
+    }
+
+    return { status: 500, body: { error: "Failed to update line item" } };
+  }
+}
+
+export async function archiveLineItem(
+  service: LineItemServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const lineItemId = getRequiredString(payload, "lineItemId");
+  const archivedBy = getOptionalString(payload, "archivedBy");
+  const reason = getOptionalString(payload, "reason") ?? undefined;
+
+  if (!lineItemId) {
+    return { status: 400, body: { error: "lineItemId is required" } };
+  }
+
+  try {
+    const data = await service.archive({ lineItemId, archivedBy, reason });
+    return { status: 200, body: { data } };
+  } catch (error) {
+    const message = asErrorMessage(error);
+    if (isNotFound(error)) {
+      return { status: 404, body: { error: "Line item not found" } };
+    }
+
+    if (message.includes("already archived")) {
+      return { status: 409, body: { error: message } };
+    }
+
+    return { status: 500, body: { error: "Failed to archive line item" } };
+  }
+}

--- a/lib/line-items/index.ts
+++ b/lib/line-items/index.ts
@@ -1,0 +1,7 @@
+export { LineItemService } from "./line-item-service";
+export type {
+  ArchiveLineItemInput,
+  CreateLineItemInput,
+  ProjectionMethod,
+  UpdateLineItemInput
+} from "./types";

--- a/lib/line-items/line-item-service.ts
+++ b/lib/line-items/line-item-service.ts
@@ -1,0 +1,155 @@
+import type { PrismaClient } from "@prisma/client";
+import { diffFields, type AuditService } from "../audit";
+import type {
+  ArchiveLineItemInput,
+  CreateLineItemInput,
+  ProjectionMethod,
+  UpdateLineItemInput
+} from "./types";
+
+const TRACKED_FIELDS = [
+  "groupId",
+  "label",
+  "projectionMethod",
+  "projectionParams",
+  "sortOrder",
+  "isActive",
+  "archivedAt"
+];
+
+function isProjectionMethod(value: unknown): value is ProjectionMethod {
+  return (
+    value === "manual" ||
+    value === "annual_spread" ||
+    value === "prior_year_pct" ||
+    value === "prior_year_flat" ||
+    value === "custom_formula"
+  );
+}
+
+export class LineItemService {
+  constructor(
+    private prisma: PrismaClient,
+    private audit: AuditService
+  ) {}
+
+  async list(input?: { groupId?: string; includeInactive?: boolean }) {
+    const where: { groupId?: string; isActive?: boolean } = {};
+
+    if (input?.groupId) {
+      where.groupId = input.groupId;
+    }
+
+    if (!input?.includeInactive) {
+      where.isActive = true;
+    }
+
+    return this.prisma.lineItem.findMany({
+      where,
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }]
+    });
+  }
+
+  async getById(lineItemId: string) {
+    return this.prisma.lineItem.findUniqueOrThrow({ where: { id: lineItemId } });
+  }
+
+  async create(input: CreateLineItemInput) {
+    const method = input.projectionMethod ?? "manual";
+
+    if (!isProjectionMethod(method)) {
+      throw new Error("Invalid projectionMethod");
+    }
+
+    const created = await this.prisma.lineItem.create({
+      data: {
+        groupId: input.groupId,
+        label: input.label,
+        projectionMethod: method,
+        projectionParams: input.projectionParams as never,
+        sortOrder: input.sortOrder ?? 0
+      }
+    });
+
+    await this.audit.logCreate({
+      userId: input.createdBy,
+      tableName: "LineItem",
+      recordId: created.id,
+      fields: {
+        groupId: created.groupId,
+        label: created.label,
+        projectionMethod: created.projectionMethod,
+        sortOrder: String(created.sortOrder),
+        isActive: String(created.isActive)
+      },
+      source: "ui_edit"
+    });
+
+    return created;
+  }
+
+  async update(input: UpdateLineItemInput) {
+    const current = await this.prisma.lineItem.findUniqueOrThrow({
+      where: { id: input.lineItemId }
+    });
+
+    if (input.projectionMethod !== undefined && !isProjectionMethod(input.projectionMethod)) {
+      throw new Error("Invalid projectionMethod");
+    }
+
+    const updated = await this.prisma.lineItem.update({
+      where: { id: input.lineItemId },
+      data: {
+        groupId: input.groupId ?? undefined,
+        label: input.label ?? undefined,
+        projectionMethod: input.projectionMethod ?? undefined,
+        projectionParams: input.projectionParams as never,
+        sortOrder: input.sortOrder ?? undefined
+      }
+    });
+
+    const changes = diffFields(
+      current as Record<string, unknown>,
+      updated as Record<string, unknown>,
+      TRACKED_FIELDS
+    );
+    await this.audit.logUpdate({
+      userId: input.updatedBy,
+      tableName: "LineItem",
+      recordId: current.id,
+      changes,
+      reason: input.reason,
+      source: "ui_edit"
+    });
+
+    return updated;
+  }
+
+  async archive(input: ArchiveLineItemInput) {
+    const current = await this.prisma.lineItem.findUniqueOrThrow({
+      where: { id: input.lineItemId }
+    });
+
+    if (!current.isActive) {
+      throw new Error("Line item is already archived");
+    }
+
+    const updated = await this.prisma.lineItem.update({
+      where: { id: input.lineItemId },
+      data: {
+        isActive: false,
+        archivedAt: new Date()
+      }
+    });
+
+    await this.audit.logArchive({
+      userId: input.archivedBy,
+      tableName: "LineItem",
+      recordId: current.id,
+      reason: input.reason,
+      source: "ui_edit"
+    });
+
+    return updated;
+  }
+}

--- a/lib/line-items/service-factory.ts
+++ b/lib/line-items/service-factory.ts
@@ -1,0 +1,7 @@
+import { prisma } from "../db";
+import { AuditService } from "../audit";
+import { LineItemService } from "./line-item-service";
+
+const auditService = new AuditService(prisma);
+
+export const lineItemService = new LineItemService(prisma, auditService);

--- a/lib/line-items/types.ts
+++ b/lib/line-items/types.ts
@@ -1,0 +1,32 @@
+export type ProjectionMethod =
+  | "manual"
+  | "annual_spread"
+  | "prior_year_pct"
+  | "prior_year_flat"
+  | "custom_formula";
+
+export interface CreateLineItemInput {
+  groupId: string;
+  label: string;
+  projectionMethod?: ProjectionMethod;
+  projectionParams?: unknown;
+  sortOrder?: number;
+  createdBy: string | null;
+}
+
+export interface UpdateLineItemInput {
+  lineItemId: string;
+  groupId?: string;
+  label?: string;
+  projectionMethod?: ProjectionMethod;
+  projectionParams?: unknown;
+  sortOrder?: number;
+  updatedBy: string | null;
+  reason?: string;
+}
+
+export interface ArchiveLineItemInput {
+  lineItemId: string;
+  archivedBy: string | null;
+  reason?: string;
+}

--- a/lib/values/http-handlers.ts
+++ b/lib/values/http-handlers.ts
@@ -1,0 +1,94 @@
+import type { ListValuesInput, UpsertValueInput } from "./types";
+
+type HandlerResult = {
+  status: number;
+  body: { data?: unknown; error?: string };
+};
+
+type ValueServiceLike = {
+  list: (input: ListValuesInput) => Promise<unknown>;
+  upsert: (input: UpsertValueInput) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
+  const value = payload[field];
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  return value;
+}
+
+function isYearMonth(value: string): boolean {
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(value);
+}
+
+export async function listValues(
+  service: ValueServiceLike,
+  snapshotId: string | null,
+  groupId?: string
+): Promise<HandlerResult> {
+  if (!snapshotId || snapshotId.trim().length === 0) {
+    return { status: 400, body: { error: "snapshotId is required" } };
+  }
+
+  try {
+    const data = await service.list({ snapshotId, groupId });
+    return { status: 200, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Failed to list values" } };
+  }
+}
+
+export async function upsertValue(service: ValueServiceLike, payload: unknown): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const lineItemId = getRequiredString(payload, "lineItemId");
+  const snapshotId = getRequiredString(payload, "snapshotId");
+  const period = getRequiredString(payload, "period");
+  const updatedBy = getOptionalString(payload, "updatedBy");
+  const projectedAmount = getOptionalString(payload, "projectedAmount");
+  const actualAmount = getOptionalString(payload, "actualAmount");
+  const note = getOptionalString(payload, "note");
+  const reason = getOptionalString(payload, "reason") ?? undefined;
+
+  if (!lineItemId || !snapshotId || !period) {
+    return { status: 400, body: { error: "lineItemId, snapshotId, and period are required" } };
+  }
+
+  if (!isYearMonth(period)) {
+    return { status: 400, body: { error: "period must be in YYYY-MM format" } };
+  }
+
+  try {
+    const data = await service.upsert({
+      lineItemId,
+      snapshotId,
+      period,
+      projectedAmount,
+      actualAmount,
+      note,
+      updatedBy,
+      reason
+    });
+
+    return { status: 200, body: { data } };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("period must be in YYYY-MM format")) {
+      return { status: 400, body: { error: error.message } };
+    }
+
+    return { status: 500, body: { error: "Failed to upsert value" } };
+  }
+}

--- a/lib/values/index.ts
+++ b/lib/values/index.ts
@@ -1,0 +1,2 @@
+export { ValueService, parsePeriod } from "./value-service";
+export type { ListValuesInput, UpsertValueInput } from "./types";

--- a/lib/values/service-factory.ts
+++ b/lib/values/service-factory.ts
@@ -1,0 +1,7 @@
+import { prisma } from "../db";
+import { AuditService } from "../audit";
+import { ValueService } from "./value-service";
+
+const auditService = new AuditService(prisma);
+
+export const valueService = new ValueService(prisma, auditService);

--- a/lib/values/types.ts
+++ b/lib/values/types.ts
@@ -1,0 +1,16 @@
+export interface ListValuesInput {
+  snapshotId: string;
+  groupId?: string;
+}
+
+export interface UpsertValueInput {
+  lineItemId: string;
+  snapshotId: string;
+  /** YYYY-MM */
+  period: string;
+  projectedAmount?: string | null;
+  actualAmount?: string | null;
+  note?: string | null;
+  updatedBy: string | null;
+  reason?: string;
+}

--- a/lib/values/value-service.ts
+++ b/lib/values/value-service.ts
@@ -1,0 +1,118 @@
+import type { PrismaClient } from "@prisma/client";
+import { diffFields, type AuditService } from "../audit";
+import type { ListValuesInput, UpsertValueInput } from "./types";
+
+function parsePeriod(period: string): Date {
+  const match = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(period);
+  if (!match) {
+    throw new Error("period must be in YYYY-MM format");
+  }
+
+  return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, 1));
+}
+
+export class ValueService {
+  constructor(
+    private prisma: PrismaClient,
+    private audit: AuditService
+  ) {}
+
+  async list(input: ListValuesInput) {
+    return this.prisma.value.findMany({
+      where: {
+        snapshotId: input.snapshotId,
+        lineItem: input.groupId ? { groupId: input.groupId } : undefined
+      },
+      orderBy: [{ period: "asc" }, { createdAt: "asc" }],
+      include: {
+        lineItem: {
+          select: {
+            id: true,
+            label: true,
+            groupId: true,
+            projectionMethod: true,
+            sortOrder: true
+          }
+        }
+      }
+    });
+  }
+
+  async upsert(input: UpsertValueInput) {
+    const periodDate = parsePeriod(input.period);
+
+    const existing = await this.prisma.value.findUnique({
+      where: {
+        lineItemId_snapshotId_period: {
+          lineItemId: input.lineItemId,
+          snapshotId: input.snapshotId,
+          period: periodDate
+        }
+      }
+    });
+
+    const upserted = await this.prisma.value.upsert({
+      where: {
+        lineItemId_snapshotId_period: {
+          lineItemId: input.lineItemId,
+          snapshotId: input.snapshotId,
+          period: periodDate
+        }
+      },
+      create: {
+        lineItemId: input.lineItemId,
+        snapshotId: input.snapshotId,
+        period: periodDate,
+        projectedAmount: input.projectedAmount ?? null,
+        actualAmount: input.actualAmount ?? null,
+        note: input.note ?? null,
+        updatedBy: input.updatedBy
+      },
+      update: {
+        projectedAmount: input.projectedAmount ?? null,
+        actualAmount: input.actualAmount ?? null,
+        note: input.note ?? null,
+        updatedBy: input.updatedBy
+      }
+    });
+
+    if (!existing) {
+      await this.audit.logCreate({
+        userId: input.updatedBy,
+        tableName: "Value",
+        recordId: upserted.id,
+        fields: {
+          lineItemId: upserted.lineItemId,
+          snapshotId: upserted.snapshotId,
+          period: upserted.period.toISOString(),
+          projectedAmount: upserted.projectedAmount?.toString() ?? null,
+          actualAmount: upserted.actualAmount?.toString() ?? null,
+          note: upserted.note
+        },
+        source: "ui_edit"
+      });
+
+      return upserted;
+    }
+
+    const changes = diffFields(existing as Record<string, unknown>, upserted as Record<string, unknown>, [
+      "projectedAmount",
+      "actualAmount",
+      "note",
+      "updatedBy"
+    ]);
+
+    await this.audit.logUpdate({
+      userId: input.updatedBy,
+      tableName: "Value",
+      recordId: upserted.id,
+      changes,
+      reason: input.reason,
+      source: "ui_edit"
+    });
+
+    return upserted;
+  }
+}
+
+export { parsePeriod };

--- a/tests/unit/line-item-http-handlers.test.ts
+++ b/tests/unit/line-item-http-handlers.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  archiveLineItem,
+  createLineItem,
+  getLineItem,
+  listLineItems,
+  updateLineItem
+} from "../../lib/line-items/http-handlers";
+
+function createMockService() {
+  return {
+    list: vi.fn().mockResolvedValue([{ id: "li-1", label: "Rent Revenue" }]),
+    getById: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: "li-new", label: "New Item" }),
+    update: vi.fn().mockResolvedValue({ id: "li-1", label: "Updated" }),
+    archive: vi.fn().mockResolvedValue({ id: "li-1", isActive: false })
+  };
+}
+
+describe("line item HTTP handlers", () => {
+  const mockService = createMockService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists line items", async () => {
+    const result = await listLineItems(mockService, "grp-1", false);
+
+    expect(result.status).toBe(200);
+    expect(result.body.data).toEqual([{ id: "li-1", label: "Rent Revenue" }]);
+  });
+
+  it("gets line item by id", async () => {
+    mockService.getById.mockResolvedValueOnce({ id: "li-1" });
+
+    const result = await getLineItem(mockService, "li-1");
+
+    expect(result.status).toBe(200);
+    expect(result.body.data).toEqual({ id: "li-1" });
+  });
+
+  it("returns 404 when line item is not found", async () => {
+    mockService.getById.mockRejectedValueOnce(new Error("No LineItem found"));
+
+    const result = await getLineItem(mockService, "missing");
+
+    expect(result.status).toBe(404);
+    expect(result.body.error).toBe("Line item not found");
+  });
+
+  it("creates line item with valid payload", async () => {
+    const payload = {
+      groupId: "grp-1",
+      label: "Tenant Rent",
+      projectionMethod: "annual_spread",
+      projectionParams: { annualTotal: "120000" },
+      sortOrder: 1,
+      createdBy: "admin-1"
+    };
+
+    const result = await createLineItem(mockService, payload);
+
+    expect(result.status).toBe(201);
+    expect(mockService.create).toHaveBeenCalledWith(payload);
+  });
+
+  it("rejects invalid projection method", async () => {
+    const result = await createLineItem(mockService, {
+      groupId: "grp-1",
+      label: "Tenant Rent",
+      projectionMethod: "bad_method"
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("Invalid projectionMethod");
+  });
+
+  it("updates line item", async () => {
+    const result = await updateLineItem(mockService, {
+      lineItemId: "li-1",
+      label: "Tenant Rent Updated",
+      updatedBy: "editor-1"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.update).toHaveBeenCalledWith({
+      lineItemId: "li-1",
+      groupId: undefined,
+      label: "Tenant Rent Updated",
+      projectionMethod: undefined,
+      projectionParams: undefined,
+      sortOrder: undefined,
+      updatedBy: "editor-1",
+      reason: undefined
+    });
+  });
+
+  it("rejects update with no updatable fields", async () => {
+    const result = await updateLineItem(mockService, {
+      lineItemId: "li-1",
+      updatedBy: "editor-1"
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("No updatable fields provided");
+  });
+
+  it("archives line item", async () => {
+    const result = await archiveLineItem(mockService, {
+      lineItemId: "li-1",
+      archivedBy: "admin-1",
+      reason: "No longer needed"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.archive).toHaveBeenCalledWith({
+      lineItemId: "li-1",
+      archivedBy: "admin-1",
+      reason: "No longer needed"
+    });
+  });
+
+  it("returns 409 when line item is already archived", async () => {
+    mockService.archive.mockRejectedValueOnce(new Error("Line item is already archived"));
+
+    const result = await archiveLineItem(mockService, {
+      lineItemId: "li-1",
+      archivedBy: "admin-1"
+    });
+
+    expect(result.status).toBe(409);
+    expect(result.body.error).toBe("Line item is already archived");
+  });
+});

--- a/tests/unit/line-item-service.test.ts
+++ b/tests/unit/line-item-service.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LineItemService } from "../../lib/line-items/line-item-service";
+
+function createMockAudit() {
+  return {
+    logCreate: vi.fn().mockResolvedValue(undefined),
+    logUpdate: vi.fn().mockResolvedValue(undefined),
+    logArchive: vi.fn().mockResolvedValue(undefined)
+  } as never;
+}
+
+function createMockPrisma() {
+  return {
+    lineItem: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUniqueOrThrow: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn()
+    }
+  } as never;
+}
+
+describe("LineItemService", () => {
+  let service: LineItemService;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+  let mockAudit: ReturnType<typeof createMockAudit>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = createMockPrisma();
+    mockAudit = createMockAudit();
+    service = new LineItemService(mockPrisma, mockAudit);
+  });
+
+  it("lists only active line items by default", async () => {
+    await service.list();
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    expect(prismaAny.lineItem.findMany).toHaveBeenCalledWith({
+      where: { isActive: true },
+      orderBy: [{ sortOrder: "asc" }, { createdAt: "asc" }]
+    });
+  });
+
+  it("creates line item and logs audit create entries", async () => {
+    const created = {
+      id: "li-1",
+      groupId: "grp-1",
+      label: "Rent",
+      projectionMethod: "manual",
+      sortOrder: 1,
+      isActive: true
+    };
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.lineItem.create.mockResolvedValue(created);
+
+    const result = await service.create({
+      groupId: "grp-1",
+      label: "Rent",
+      projectionMethod: "manual",
+      sortOrder: 1,
+      createdBy: "admin-1"
+    });
+
+    expect(result.id).toBe("li-1");
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logCreate).toHaveBeenCalledOnce();
+  });
+
+  it("updates line item and logs field-level changes", async () => {
+    const current = {
+      id: "li-1",
+      groupId: "grp-1",
+      label: "Rent",
+      projectionMethod: "manual",
+      projectionParams: null,
+      sortOrder: 1,
+      isActive: true,
+      archivedAt: null
+    };
+    const updated = {
+      ...current,
+      projectionMethod: "annual_spread",
+      sortOrder: 2
+    };
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.lineItem.findUniqueOrThrow.mockResolvedValue(current);
+    prismaAny.lineItem.update.mockResolvedValue(updated);
+
+    await service.update({
+      lineItemId: "li-1",
+      projectionMethod: "annual_spread",
+      sortOrder: 2,
+      updatedBy: "editor-1",
+      reason: "Switch to annual estimate"
+    });
+
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logUpdate).toHaveBeenCalledOnce();
+    const changes = auditAny.logUpdate.mock.calls[0][0].changes;
+    expect(changes.some((c: { field: string }) => c.field === "projectionMethod")).toBe(true);
+    expect(changes.some((c: { field: string }) => c.field === "sortOrder")).toBe(true);
+  });
+
+  it("archives line item and logs archive event", async () => {
+    const current = {
+      id: "li-1",
+      isActive: true
+    };
+    const updated = {
+      id: "li-1",
+      isActive: false,
+      archivedAt: new Date()
+    };
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.lineItem.findUniqueOrThrow.mockResolvedValue(current);
+    prismaAny.lineItem.update.mockResolvedValue(updated);
+
+    const result = await service.archive({
+      lineItemId: "li-1",
+      archivedBy: "admin-1",
+      reason: "Deprecated"
+    });
+
+    expect(result.isActive).toBe(false);
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logArchive).toHaveBeenCalledOnce();
+  });
+
+  it("throws when trying to archive an already archived line item", async () => {
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.lineItem.findUniqueOrThrow.mockResolvedValue({ id: "li-1", isActive: false });
+
+    await expect(service.archive({ lineItemId: "li-1", archivedBy: "admin-1" })).rejects.toThrow(
+      "Line item is already archived"
+    );
+  });
+});

--- a/tests/unit/value-http-handlers.test.ts
+++ b/tests/unit/value-http-handlers.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { listValues, upsertValue } from "../../lib/values/http-handlers";
+
+function createMockService() {
+  return {
+    list: vi.fn().mockResolvedValue([{ id: "v1" }]),
+    upsert: vi.fn().mockResolvedValue({ id: "v1" })
+  };
+}
+
+describe("value HTTP handlers", () => {
+  const mockService = createMockService();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists values for snapshot", async () => {
+    const result = await listValues(mockService, "snap-1", "grp-1");
+
+    expect(result.status).toBe(200);
+    expect(mockService.list).toHaveBeenCalledWith({ snapshotId: "snap-1", groupId: "grp-1" });
+  });
+
+  it("requires snapshotId for listing", async () => {
+    const result = await listValues(mockService, null);
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("snapshotId is required");
+  });
+
+  it("upserts value with valid payload", async () => {
+    const result = await upsertValue(mockService, {
+      lineItemId: "li-1",
+      snapshotId: "snap-1",
+      period: "2026-01",
+      projectedAmount: "1000.00",
+      actualAmount: "950.00",
+      note: "Updated",
+      updatedBy: "user-1"
+    });
+
+    expect(result.status).toBe(200);
+    expect(mockService.upsert).toHaveBeenCalledWith({
+      lineItemId: "li-1",
+      snapshotId: "snap-1",
+      period: "2026-01",
+      projectedAmount: "1000.00",
+      actualAmount: "950.00",
+      note: "Updated",
+      updatedBy: "user-1",
+      reason: undefined
+    });
+  });
+
+  it("requires core fields for upsert", async () => {
+    const result = await upsertValue(mockService, {
+      snapshotId: "snap-1",
+      period: "2026-01"
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("lineItemId, snapshotId, and period are required");
+  });
+
+  it("validates period format", async () => {
+    const result = await upsertValue(mockService, {
+      lineItemId: "li-1",
+      snapshotId: "snap-1",
+      period: "2026/01"
+    });
+
+    expect(result.status).toBe(400);
+    expect(result.body.error).toBe("period must be in YYYY-MM format");
+  });
+});

--- a/tests/unit/value-service.test.ts
+++ b/tests/unit/value-service.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { parsePeriod, ValueService } from "../../lib/values/value-service";
+
+function createMockAudit() {
+  return {
+    logCreate: vi.fn().mockResolvedValue(undefined),
+    logUpdate: vi.fn().mockResolvedValue(undefined)
+  } as never;
+}
+
+function createMockPrisma() {
+  return {
+    value: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findUnique: vi.fn(),
+      upsert: vi.fn()
+    }
+  } as never;
+}
+
+describe("parsePeriod", () => {
+  it("parses YYYY-MM into UTC first day", () => {
+    const parsed = parsePeriod("2026-03");
+    expect(parsed.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("throws on invalid format", () => {
+    expect(() => parsePeriod("2026/03")).toThrow("period must be in YYYY-MM format");
+  });
+});
+
+describe("ValueService", () => {
+  let service: ValueService;
+  let mockPrisma: ReturnType<typeof createMockPrisma>;
+  let mockAudit: ReturnType<typeof createMockAudit>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma = createMockPrisma();
+    mockAudit = createMockAudit();
+    service = new ValueService(mockPrisma, mockAudit);
+  });
+
+  it("lists values with snapshot/group filters", async () => {
+    await service.list({ snapshotId: "snap-1", groupId: "grp-1" });
+
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    expect(prismaAny.value.findMany).toHaveBeenCalledWith({
+      where: {
+        snapshotId: "snap-1",
+        lineItem: { groupId: "grp-1" }
+      },
+      orderBy: [{ period: "asc" }, { createdAt: "asc" }],
+      include: {
+        lineItem: {
+          select: {
+            id: true,
+            label: true,
+            groupId: true,
+            projectionMethod: true,
+            sortOrder: true
+          }
+        }
+      }
+    });
+  });
+
+  it("creates new value and logs audit create", async () => {
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.value.findUnique.mockResolvedValue(null);
+    prismaAny.value.upsert.mockResolvedValue({
+      id: "v-1",
+      lineItemId: "li-1",
+      snapshotId: "snap-1",
+      period: new Date("2026-01-01T00:00:00.000Z"),
+      projectedAmount: { toString: () => "1000.00" },
+      actualAmount: { toString: () => "900.00" },
+      note: "new"
+    });
+
+    await service.upsert({
+      lineItemId: "li-1",
+      snapshotId: "snap-1",
+      period: "2026-01",
+      projectedAmount: "1000.00",
+      actualAmount: "900.00",
+      note: "new",
+      updatedBy: "user-1"
+    });
+
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logCreate).toHaveBeenCalledOnce();
+  });
+
+  it("updates existing value and logs audit update", async () => {
+    const prismaAny = mockPrisma as Record<string, Record<string, ReturnType<typeof vi.fn>>>;
+    prismaAny.value.findUnique.mockResolvedValue({
+      id: "v-1",
+      projectedAmount: "1000.00",
+      actualAmount: "900.00",
+      note: "old",
+      updatedBy: "user-1"
+    });
+    prismaAny.value.upsert.mockResolvedValue({
+      id: "v-1",
+      projectedAmount: "1100.00",
+      actualAmount: "900.00",
+      note: "revised",
+      updatedBy: "user-2"
+    });
+
+    await service.upsert({
+      lineItemId: "li-1",
+      snapshotId: "snap-1",
+      period: "2026-01",
+      projectedAmount: "1100.00",
+      actualAmount: "900.00",
+      note: "revised",
+      updatedBy: "user-2",
+      reason: "variance update"
+    });
+
+    const auditAny = mockAudit as Record<string, ReturnType<typeof vi.fn>>;
+    expect(auditAny.logUpdate).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- **Backend** (Codex): `LineItemService` and `ValueService` with full CRUD, HTTP handlers, API routes (`/api/line-items`, `/api/values`), and 24 unit tests
- **Frontend** (Claude): `ProjectionStrategyPicker` component with method-specific parameter inputs:
  - Annual Spread: annual total input with live monthly breakdown preview
  - Prior Year +/- %: percentage input with direction indicator
  - Prior Year Flat / Manual: no additional params needed
- `LineItemManager` component for per-group line item CRUD with inline projection editing
- Admin page at `/admin/line-items` with group selector sidebar and line item management

## API Endpoints
- `GET /api/line-items?groupId=xxx&includeInactive=true` — list line items
- `POST /api/line-items` — create line item with projection config
- `GET /api/line-items/:id` — get single line item
- `PATCH /api/line-items/:id` — update (including projection method/params)
- `DELETE /api/line-items/:id` — archive (soft delete per ADR-002)
- `GET /api/values?snapshotId=xxx` — list values for a snapshot
- `POST /api/values/upsert` — create or update a value

## Test plan
- [x] 207 tests passing (24 new from Codex + existing)
- [x] TypeScript clean (`tsc --noEmit` passes)
- [ ] Visual testing of projection picker UI
- [ ] Integration test: create line item → verify in grid

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)