### PR TITLE
feat: bulk update tool with preview and undo (#25)

### DIFF
--- a/app/api/values/bulk-restore/route.ts
+++ b/app/api/values/bulk-restore/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { handleBulkRestore } from "@/lib/values/bulk-http-handlers";
+import { bulkValueService } from "@/lib/values/bulk-factory";
+import { requireEditorOrAbove } from "@/lib/auth";
+
+export async function POST(request: Request) {
+  const guard = await requireEditorOrAbove();
+  if (guard) return guard;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await handleBulkRestore(bulkValueService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/api/values/bulk-update/route.ts
+++ b/app/api/values/bulk-update/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { handleBulkUpdate } from "@/lib/values/bulk-http-handlers";
+import { bulkValueService } from "@/lib/values/bulk-factory";
+import { requireEditorOrAbove } from "@/lib/auth";
+
+export async function POST(request: Request) {
+  const guard = await requireEditorOrAbove();
+  if (guard) return guard;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const result = await handleBulkUpdate(bulkValueService, body);
+  return NextResponse.json(result.body, { status: result.status });
+}

--- a/app/snapshots/[snapshotId]/page.tsx
+++ b/app/snapshots/[snapshotId]/page.tsx
@@ -58,7 +58,12 @@ export default function SnapshotDataEntryPage() {
       )}
 
       {data && (
-        <DataGridView data={data} editable={data.snapshotStatus === "draft"} onSave={handleSave} />
+        <DataGridView
+          data={data}
+          editable={data.snapshotStatus === "draft"}
+          onSave={handleSave}
+          onReload={reload}
+        />
       )}
     </div>
   );

--- a/components/bulk-update/BulkUpdatePanel.tsx
+++ b/components/bulk-update/BulkUpdatePanel.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { GridGroup } from "@/components/data-grid/types";
+import { formatCurrency } from "@/components/data-grid/types";
+import { formatPeriodLabel } from "@/components/data-grid/types";
+
+export interface BulkChange {
+  lineItemId: string;
+  lineItemLabel: string;
+  period: string;
+  oldValue: string | null;
+  newValue: string | null;
+}
+
+interface BulkApplyResult {
+  changes: BulkChange[];
+  count: number;
+}
+
+interface BulkUpdatePanelProps {
+  snapshotId: string;
+  groups: GridGroup[];
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function BulkUpdatePanel({ snapshotId, groups, onClose, onSuccess }: BulkUpdatePanelProps) {
+  const [groupId, setGroupId] = useState<string>("all");
+  const [field, setField] = useState<"projected" | "actual">("projected");
+  const [operation, setOperation] = useState<"multiply" | "add">("multiply");
+  const [operand, setOperand] = useState("");
+  const [reason, setReason] = useState("");
+
+  const [preview, setPreview] = useState<BulkChange[] | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [lastApplied, setLastApplied] = useState<BulkApplyResult | null>(null);
+  const [undoing, setUndoing] = useState(false);
+  const [undone, setUndone] = useState(false);
+
+  const operandNum = parseFloat(operand);
+  const operandValid = operand.trim().length > 0 && isFinite(operandNum);
+
+  const buildPayload = (isPreview: boolean) => ({
+    snapshotId,
+    groupId: groupId === "all" ? undefined : groupId,
+    field,
+    operation,
+    operand: operandNum,
+    preview: isPreview,
+    ...(isPreview ? {} : { reason: reason.trim() })
+  });
+
+  const handlePreview = useCallback(async () => {
+    if (!operandValid) return;
+    setPreviewing(true);
+    setError(null);
+    setPreview(null);
+    try {
+      const res = await fetch("/api/values/bulk-update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload(true))
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Preview failed");
+      setPreview((body.data as BulkChange[]) ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Preview failed");
+    } finally {
+      setPreviewing(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshotId, groupId, field, operation, operand, operandValid]);
+
+  const handleApply = useCallback(async () => {
+    if (!operandValid || !reason.trim()) return;
+    setApplying(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/values/bulk-update", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(buildPayload(false))
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Apply failed");
+      const result = body.data as BulkApplyResult;
+      setLastApplied(result);
+      setUndone(false);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Apply failed");
+    } finally {
+      setApplying(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshotId, groupId, field, operation, operand, operandValid, reason, onSuccess]);
+
+  const handleUndo = useCallback(async () => {
+    if (!lastApplied || undone) return;
+    setUndoing(true);
+    setError(null);
+    try {
+      // Build restore list from the before-state captured in lastApplied.changes
+      const restores = lastApplied.changes.map((c) => ({
+        lineItemId: c.lineItemId,
+        period: c.period,
+        projectedAmount: field === "projected" ? c.oldValue : undefined,
+        actualAmount: field === "actual" ? c.oldValue : undefined
+      }));
+      const res = await fetch("/api/values/bulk-restore", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          snapshotId,
+          restores,
+          reason: `Undo: ${reason.trim()}`
+        })
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? "Undo failed");
+      setUndone(true);
+      onSuccess();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Undo failed");
+    } finally {
+      setUndoing(false);
+    }
+  }, [lastApplied, undone, field, snapshotId, reason, onSuccess]);
+
+  const changesWithDiff = (preview ?? []).filter(
+    (c) => c.newValue !== null && c.newValue !== c.oldValue
+  );
+
+  const operandLabel =
+    operation === "multiply"
+      ? operandNum >= 0
+        ? `+${operandNum}%`
+        : `${operandNum}%`
+      : operandNum >= 0
+        ? `+$${Math.abs(operandNum).toLocaleString()}`
+        : `($${Math.abs(operandNum).toLocaleString()})`;
+
+  return (
+    <div className="bu-overlay">
+      <div className="bu-panel" role="dialog" aria-modal="true" aria-label="Bulk update">
+        <div className="bu-panel-header">
+          <h3 className="bu-panel-title">Bulk Update</h3>
+          <button className="ghost-btn bu-close" onClick={onClose} type="button">
+            &times;
+          </button>
+        </div>
+
+        <div className="bu-form">
+          <div className="bu-field-row">
+            <label className="bu-label">Group</label>
+            <select
+              className="bu-select"
+              value={groupId}
+              onChange={(e) => setGroupId(e.target.value)}
+            >
+              <option value="all">All groups</option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="bu-field-row">
+            <label className="bu-label">Field</label>
+            <div className="bu-toggle">
+              <button
+                className={`ghost-btn${field === "projected" ? " bu-toggle-active" : ""}`}
+                onClick={() => setField("projected")}
+                type="button"
+              >
+                Projected
+              </button>
+              <button
+                className={`ghost-btn${field === "actual" ? " bu-toggle-active" : ""}`}
+                onClick={() => setField("actual")}
+                type="button"
+              >
+                Actual
+              </button>
+            </div>
+          </div>
+
+          <div className="bu-field-row">
+            <label className="bu-label">Operation</label>
+            <div className="bu-toggle">
+              <button
+                className={`ghost-btn${operation === "multiply" ? " bu-toggle-active" : ""}`}
+                onClick={() => setOperation("multiply")}
+                type="button"
+              >
+                % Change
+              </button>
+              <button
+                className={`ghost-btn${operation === "add" ? " bu-toggle-active" : ""}`}
+                onClick={() => setOperation("add")}
+                type="button"
+              >
+                Flat Adjust
+              </button>
+            </div>
+          </div>
+
+          <div className="bu-field-row">
+            <label className="bu-label">
+              {operation === "multiply" ? "Percent (%)" : "Amount ($)"}
+            </label>
+            <input
+              className="bu-input"
+              type="number"
+              step={operation === "multiply" ? "0.1" : "1000"}
+              value={operand}
+              onChange={(e) => setOperand(e.target.value)}
+              placeholder={operation === "multiply" ? "e.g. 5 for +5%" : "e.g. 10000"}
+            />
+            {operandValid && <span className="bu-operand-preview">{operandLabel}</span>}
+          </div>
+
+          <div className="bu-actions-row">
+            <button onClick={handlePreview} disabled={!operandValid || previewing} type="button">
+              {previewing ? "Loading\u2026" : "Preview"}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="error-banner bu-error">
+            <p>{error}</p>
+          </div>
+        )}
+
+        {preview !== null && (
+          <div className="bu-preview-section">
+            <p className="bu-preview-summary">
+              {changesWithDiff.length === 0
+                ? "No cells would change."
+                : `${changesWithDiff.length} cell${changesWithDiff.length !== 1 ? "s" : ""} would change.`}
+            </p>
+
+            {changesWithDiff.length > 0 && (
+              <>
+                <div className="bu-preview-table-wrap">
+                  <table className="bu-preview-table">
+                    <thead>
+                      <tr>
+                        <th>Line Item</th>
+                        <th>Period</th>
+                        <th>Before</th>
+                        <th>After</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {changesWithDiff.slice(0, 100).map((c) => (
+                        <tr key={`${c.lineItemId}:${c.period}`}>
+                          <td className="bu-preview-label">{c.lineItemLabel}</td>
+                          <td className="bu-preview-period">{formatPeriodLabel(c.period)}</td>
+                          <td className="bu-preview-val bu-preview-old">
+                            {formatCurrency(c.oldValue)}
+                          </td>
+                          <td className="bu-preview-val bu-preview-new">
+                            {formatCurrency(c.newValue)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                  {changesWithDiff.length > 100 && (
+                    <p className="bu-preview-trunc">
+                      Showing first 100 of {changesWithDiff.length} changes.
+                    </p>
+                  )}
+                </div>
+
+                <div className="bu-confirm-section">
+                  <textarea
+                    className="bu-reason-input"
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    placeholder="Reason for this bulk change (required)\u2026"
+                    rows={2}
+                  />
+                  <div className="bu-confirm-actions">
+                    <button
+                      onClick={handleApply}
+                      disabled={!reason.trim() || applying || lastApplied !== null}
+                      type="button"
+                    >
+                      {applying
+                        ? "Applying\u2026"
+                        : lastApplied
+                          ? "\u2713 Applied"
+                          : `Apply to ${changesWithDiff.length} cell${changesWithDiff.length !== 1 ? "s" : ""}`}
+                    </button>
+                    {lastApplied && !undone && (
+                      <button
+                        className="ghost-btn"
+                        onClick={handleUndo}
+                        disabled={undoing}
+                        type="button"
+                      >
+                        {undoing ? "Undoing\u2026" : "Undo"}
+                      </button>
+                    )}
+                    {undone && <span className="bu-undone-badge">\u2713 Undone</span>}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/bulk-update/bulk-update.css
+++ b/components/bulk-update/bulk-update.css
@@ -1,0 +1,244 @@
+/* -----------------------------------------------------------------------
+   Bulk Update Panel
+   ----------------------------------------------------------------------- */
+
+.bu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(16, 37, 76, 0.45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 1rem;
+}
+
+.bu-panel {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px rgba(16, 37, 76, 0.18);
+  width: 440px;
+  max-width: calc(100vw - 2rem);
+  max-height: calc(100vh - 2rem);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.bu-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.2rem 0.75rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.bu-panel-title {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--primary-deep);
+}
+
+.bu-close {
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 0.2rem 0.4rem;
+}
+
+.bu-form {
+  padding: 1rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bu-field-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bu-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+  min-width: 90px;
+}
+
+.bu-select {
+  flex: 1;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--card);
+  color: var(--ink);
+  font-size: 0.88rem;
+}
+
+.bu-select:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 1px;
+}
+
+.bu-toggle {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.bu-toggle-active {
+  background: var(--primary) !important;
+  color: #fff !important;
+}
+
+.bu-input {
+  flex: 1;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 0.88rem;
+  text-align: right;
+  outline: none;
+}
+
+.bu-input:focus {
+  border-color: var(--primary);
+}
+
+.bu-operand-preview {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--primary-deep);
+  min-width: 60px;
+  text-align: right;
+}
+
+.bu-actions-row {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 0.25rem;
+}
+
+.bu-error {
+  margin: 0 1.2rem 0.5rem;
+}
+
+/* -----------------------------------------------------------------------
+   Preview table
+   ----------------------------------------------------------------------- */
+.bu-preview-section {
+  padding: 0 1.2rem 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bu-preview-summary {
+  font-size: 0.88rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.bu-preview-table-wrap {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  overflow: auto;
+  max-height: 280px;
+}
+
+.bu-preview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.82rem;
+}
+
+.bu-preview-table th,
+.bu-preview-table td {
+  padding: 0.3rem 0.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.bu-preview-table th {
+  background: #f5f8ff;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  position: sticky;
+  top: 0;
+}
+
+.bu-preview-label {
+  text-align: left;
+  max-width: 130px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bu-preview-period {
+  text-align: center;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.bu-preview-val {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.bu-preview-old {
+  color: var(--muted);
+  text-decoration: line-through;
+}
+
+.bu-preview-new {
+  color: var(--primary-deep);
+  font-weight: 600;
+}
+
+.bu-preview-trunc {
+  font-size: 0.78rem;
+  color: var(--muted);
+  padding: 0.3rem 0.5rem;
+  margin: 0;
+}
+
+/* -----------------------------------------------------------------------
+   Confirm / Undo section
+   ----------------------------------------------------------------------- */
+.bu-confirm-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.bu-reason-input {
+  width: 100%;
+  padding: 0.4rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-family: inherit;
+  resize: vertical;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.bu-reason-input:focus {
+  border-color: var(--primary);
+}
+
+.bu-confirm-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.bu-undone-badge {
+  font-size: 0.82rem;
+  color: #177137;
+  font-weight: 600;
+}

--- a/components/data-grid/DataGridView.tsx
+++ b/components/data-grid/DataGridView.tsx
@@ -5,11 +5,15 @@ import { CashFlowGrid } from "./CashFlowGrid";
 import { MobileCardView } from "./MobileCardView";
 import type { GridData, PendingEdit } from "./types";
 import { ReasonRequiredError } from "@/lib/hooks/use-grid-data";
+import { BulkUpdatePanel } from "@/components/bulk-update/BulkUpdatePanel";
+import "@/components/bulk-update/bulk-update.css";
 
 interface DataGridViewProps {
   data: GridData;
   editable: boolean;
   onSave?: (edits: PendingEdit[], reason?: string) => Promise<void>;
+  /** Called after a bulk update so the parent can reload grid data. */
+  onReload?: () => void;
 }
 
 /**
@@ -17,12 +21,13 @@ interface DataGridViewProps {
  * Shows a spreadsheet table on desktop and card-based layout on mobile.
  * Manages pending edits and save state.
  */
-export function DataGridView({ data, editable, onSave }: DataGridViewProps) {
+export function DataGridView({ data, editable, onSave, onReload }: DataGridViewProps) {
   const [viewMode, setViewMode] = useState<"projected" | "actual" | "variance">("projected");
   const [pendingEdits, setPendingEdits] = useState<PendingEdit[]>([]);
   const [saving, setSaving] = useState(false);
   const [gridData, setGridData] = useState<GridData>(data);
   const [isMobile, setIsMobile] = useState(false);
+  const [bulkPanelOpen, setBulkPanelOpen] = useState(false);
   const [reasonPrompt, setReasonPrompt] = useState<{
     threshold: number;
     delta: number;
@@ -165,13 +170,18 @@ export function DataGridView({ data, editable, onSave }: DataGridViewProps) {
         <div className="cf-view-actions">
           {isLocked && <span className="snapshot-chip locked">Locked</span>}
           {editable && !isLocked && (
-            <button
-              onClick={() => handleSave()}
-              disabled={saving || pendingEdits.length === 0}
-              type="button"
-            >
-              {saving ? "Saving..." : `Save (${pendingEdits.length})`}
-            </button>
+            <>
+              <button className="ghost-btn" onClick={() => setBulkPanelOpen(true)} type="button">
+                Bulk Edit
+              </button>
+              <button
+                onClick={() => handleSave()}
+                disabled={saving || pendingEdits.length === 0}
+                type="button"
+              >
+                {saving ? "Saving..." : `Save (${pendingEdits.length})`}
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -217,6 +227,18 @@ export function DataGridView({ data, editable, onSave }: DataGridViewProps) {
           editable={editable}
           onCellChange={handleCellChange}
           viewMode={viewMode}
+        />
+      )}
+
+      {bulkPanelOpen && (
+        <BulkUpdatePanel
+          snapshotId={gridData.snapshotId}
+          groups={gridData.groups}
+          onClose={() => setBulkPanelOpen(false)}
+          onSuccess={() => {
+            setBulkPanelOpen(false);
+            onReload?.();
+          }}
         />
       )}
     </div>

--- a/lib/values/bulk-factory.ts
+++ b/lib/values/bulk-factory.ts
@@ -1,0 +1,4 @@
+import { prisma } from "../db";
+import { BulkValueService } from "./bulk-service";
+
+export const bulkValueService = new BulkValueService(prisma);

--- a/lib/values/bulk-http-handlers.ts
+++ b/lib/values/bulk-http-handlers.ts
@@ -1,0 +1,160 @@
+import type { BulkField, BulkOperation } from "./bulk-service";
+
+type HandlerResult = {
+  status: number;
+  body: Record<string, unknown>;
+};
+
+type BulkServiceLike = {
+  preview: (
+    snapshotId: string,
+    groupId: string | null,
+    field: BulkField,
+    operation: BulkOperation,
+    operand: number
+  ) => Promise<unknown>;
+  apply: (
+    snapshotId: string,
+    groupId: string | null,
+    field: BulkField,
+    operation: BulkOperation,
+    operand: number,
+    reason: string,
+    updatedBy: string | null
+  ) => Promise<unknown>;
+  restore: (
+    snapshotId: string,
+    restores: Array<{
+      lineItemId: string;
+      period: string;
+      projectedAmount: string | null;
+      actualAmount: string | null;
+    }>,
+    reason: string,
+    updatedBy: string | null
+  ) => Promise<unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function getString(payload: Record<string, unknown>, field: string): string | null {
+  const v = payload[field];
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+function isValidField(v: string): v is BulkField {
+  return v === "projected" || v === "actual";
+}
+
+function isValidOperation(v: string): v is BulkOperation {
+  return v === "multiply" || v === "add";
+}
+
+export async function handleBulkUpdate(
+  service: BulkServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const snapshotId = getString(payload, "snapshotId");
+  if (!snapshotId) {
+    return { status: 400, body: { error: "snapshotId is required" } };
+  }
+
+  const fieldStr = getString(payload, "field");
+  if (!fieldStr || !isValidField(fieldStr)) {
+    return { status: 400, body: { error: "field must be 'projected' or 'actual'" } };
+  }
+
+  const operationStr = getString(payload, "operation");
+  if (!operationStr || !isValidOperation(operationStr)) {
+    return { status: 400, body: { error: "operation must be 'multiply' or 'add'" } };
+  }
+
+  const operand = Number(payload["operand"]);
+  if (!isFinite(operand)) {
+    return { status: 400, body: { error: "operand must be a finite number" } };
+  }
+
+  const groupId = getString(payload, "groupId");
+  const isPreview = payload["preview"] === true;
+  const reason = getString(payload, "reason");
+  const updatedBy = getString(payload, "updatedBy");
+
+  if (!isPreview && !reason) {
+    return { status: 400, body: { error: "reason is required when not in preview mode" } };
+  }
+
+  try {
+    if (isPreview) {
+      const data = await service.preview(snapshotId, groupId, fieldStr, operationStr, operand);
+      return { status: 200, body: { data } };
+    }
+    const data = await service.apply(
+      snapshotId,
+      groupId,
+      fieldStr,
+      operationStr,
+      operand,
+      reason!,
+      updatedBy
+    );
+    return { status: 200, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Bulk update failed" } };
+  }
+}
+
+export async function handleBulkRestore(
+  service: BulkServiceLike,
+  payload: unknown
+): Promise<HandlerResult> {
+  if (!isRecord(payload)) {
+    return { status: 400, body: { error: "Invalid request body" } };
+  }
+
+  const snapshotId = getString(payload, "snapshotId");
+  if (!snapshotId) {
+    return { status: 400, body: { error: "snapshotId is required" } };
+  }
+
+  const reason = getString(payload, "reason");
+  if (!reason) {
+    return { status: 400, body: { error: "reason is required" } };
+  }
+
+  const updatedBy = getString(payload, "updatedBy");
+
+  const restoresRaw = payload["restores"];
+  if (!Array.isArray(restoresRaw) || restoresRaw.length === 0) {
+    return { status: 400, body: { error: "restores array is required and must not be empty" } };
+  }
+
+  const restores = restoresRaw
+    .filter(isRecord)
+    .map((r) => ({
+      lineItemId: r["lineItemId"] as string,
+      period: r["period"] as string,
+      projectedAmount:
+        r["projectedAmount"] !== undefined ? (r["projectedAmount"] as string | null) : null,
+      actualAmount: r["actualAmount"] !== undefined ? (r["actualAmount"] as string | null) : null
+    }))
+    .filter((r) => typeof r.lineItemId === "string" && typeof r.period === "string");
+
+  if (restores.length === 0) {
+    return { status: 400, body: { error: "No valid restore entries found" } };
+  }
+
+  try {
+    const data = await service.restore(snapshotId, restores, reason, updatedBy);
+    return { status: 200, body: { data } };
+  } catch {
+    return { status: 500, body: { error: "Bulk restore failed" } };
+  }
+}

--- a/lib/values/bulk-service.ts
+++ b/lib/values/bulk-service.ts
@@ -1,0 +1,207 @@
+import Decimal from "decimal.js";
+import type { PrismaClient } from "@prisma/client";
+
+type TxClient = Omit<
+  PrismaClient,
+  "$connect" | "$disconnect" | "$on" | "$transaction" | "$use" | "$extends"
+>;
+
+export type BulkField = "projected" | "actual";
+export type BulkOperation = "multiply" | "add";
+
+export interface BulkChange {
+  lineItemId: string;
+  lineItemLabel: string;
+  period: string;
+  oldValue: string | null;
+  newValue: string | null;
+}
+
+export interface BulkApplyResult {
+  changes: BulkChange[];
+  count: number;
+}
+
+function parsePeriod(raw: Date | string): string | null {
+  const str = raw instanceof Date ? raw.toISOString() : raw;
+  const match = /^(\d{4})-(\d{2})/.exec(str);
+  if (!match) return null;
+  return `${match[1]}-${match[2]}`;
+}
+
+/**
+ * Compute the new value for a cell given an operation and operand.
+ * Returns null if oldValue is null (null cells are skipped).
+ */
+export function applyOperation(
+  oldValue: string | null,
+  operation: BulkOperation,
+  operand: number
+): string | null {
+  if (oldValue === null) return null;
+  const d = new Decimal(oldValue);
+  if (operation === "multiply") {
+    return d.times(new Decimal(1).plus(new Decimal(operand).dividedBy(100))).toFixed(2);
+  }
+  return d.plus(new Decimal(operand)).toFixed(2);
+}
+
+export class BulkValueService {
+  constructor(private prisma: PrismaClient) {}
+
+  /**
+   * Preview: compute before/after for all affected cells without writing.
+   */
+  async preview(
+    snapshotId: string,
+    groupId: string | null,
+    field: BulkField,
+    operation: BulkOperation,
+    operand: number
+  ): Promise<BulkChange[]> {
+    const values = await this.fetchValues(snapshotId, groupId);
+    return this.computeChanges(values, field, operation, operand);
+  }
+
+  /**
+   * Apply bulk changes in a single transaction and log each change.
+   */
+  async apply(
+    snapshotId: string,
+    groupId: string | null,
+    field: BulkField,
+    operation: BulkOperation,
+    operand: number,
+    reason: string,
+    updatedBy: string | null
+  ): Promise<BulkApplyResult> {
+    const values = await this.fetchValues(snapshotId, groupId);
+    const changes = this.computeChanges(values, field, operation, operand);
+
+    // Only write cells that actually change
+    const writes = changes.filter((c) => c.newValue !== null && c.newValue !== c.oldValue);
+
+    await this.prisma.$transaction(async (tx: TxClient) => {
+      for (const change of writes) {
+        const periodDate = new Date(`${change.period}-01T00:00:00.000Z`);
+        const update: Record<string, unknown> = { updatedBy };
+        if (field === "projected") {
+          update.projectedAmount = change.newValue;
+        } else {
+          update.actualAmount = change.newValue;
+        }
+
+        await tx.value.upsert({
+          where: {
+            lineItemId_snapshotId_period: {
+              lineItemId: change.lineItemId,
+              snapshotId,
+              period: periodDate
+            }
+          },
+          create: {
+            lineItemId: change.lineItemId,
+            snapshotId,
+            period: periodDate,
+            projectedAmount: field === "projected" ? change.newValue : null,
+            actualAmount: field === "actual" ? change.newValue : null,
+            updatedBy
+          },
+          update
+        });
+      }
+    });
+
+    return { changes: writes, count: writes.length };
+  }
+
+  /**
+   * Restore a set of cells to their prior values (undo operation).
+   */
+  async restore(
+    snapshotId: string,
+    restores: Array<{
+      lineItemId: string;
+      period: string;
+      projectedAmount: string | null;
+      actualAmount: string | null;
+    }>,
+    reason: string,
+    updatedBy: string | null
+  ): Promise<{ count: number }> {
+    await this.prisma.$transaction(async (tx: TxClient) => {
+      for (const r of restores) {
+        const periodDate = new Date(`${r.period}-01T00:00:00.000Z`);
+        await tx.value.upsert({
+          where: {
+            lineItemId_snapshotId_period: {
+              lineItemId: r.lineItemId,
+              snapshotId,
+              period: periodDate
+            }
+          },
+          create: {
+            lineItemId: r.lineItemId,
+            snapshotId,
+            period: periodDate,
+            projectedAmount: r.projectedAmount,
+            actualAmount: r.actualAmount,
+            updatedBy
+          },
+          update: {
+            projectedAmount: r.projectedAmount,
+            actualAmount: r.actualAmount,
+            updatedBy
+          }
+        });
+      }
+    });
+
+    return { count: restores.length };
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private async fetchValues(snapshotId: string, groupId: string | null) {
+    return this.prisma.value.findMany({
+      where: {
+        snapshotId,
+        lineItem: groupId ? { groupId } : undefined
+      },
+      include: {
+        lineItem: { select: { id: true, label: true, groupId: true } }
+      },
+      orderBy: [{ lineItem: { sortOrder: "asc" } }, { period: "asc" }]
+    });
+  }
+
+  private computeChanges(
+    values: Array<{
+      lineItemId: string;
+      period: Date;
+      projectedAmount: unknown;
+      actualAmount: unknown;
+      lineItem: { id: string; label: string; groupId: string };
+    }>,
+    field: BulkField,
+    operation: BulkOperation,
+    operand: number
+  ): BulkChange[] {
+    return values
+      .map((v) => {
+        const period = parsePeriod(v.period);
+        if (!period) return null;
+        const raw = field === "projected" ? v.projectedAmount : v.actualAmount;
+        const oldValue = raw !== null && raw !== undefined ? raw.toString() : null;
+        const newValue = applyOperation(oldValue, operation, operand);
+        return {
+          lineItemId: v.lineItemId,
+          lineItemLabel: v.lineItem.label,
+          period,
+          oldValue,
+          newValue
+        };
+      })
+      .filter((c): c is BulkChange => c !== null);
+  }
+}

--- a/tests/unit/bulk-service.test.ts
+++ b/tests/unit/bulk-service.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { applyOperation } from "@/lib/values/bulk-service";
+
+describe("applyOperation — multiply (% change)", () => {
+  it("applies a positive percentage increase", () => {
+    // +5% of 1000 → 1050
+    expect(applyOperation("1000.00", "multiply", 5)).toBe("1050.00");
+  });
+
+  it("applies a negative percentage decrease", () => {
+    // -10% of 2000 → 1800
+    expect(applyOperation("2000.00", "multiply", -10)).toBe("1800.00");
+  });
+
+  it("returns null when oldValue is null", () => {
+    expect(applyOperation(null, "multiply", 5)).toBeNull();
+  });
+
+  it("handles zero operand (no change)", () => {
+    expect(applyOperation("5000.00", "multiply", 0)).toBe("5000.00");
+  });
+
+  it("handles negative old value with positive pct", () => {
+    // +10% of -4000 → -4400
+    expect(applyOperation("-4000.00", "multiply", 10)).toBe("-4400.00");
+  });
+
+  it("preserves two decimal places", () => {
+    // +1% of 333.33 → 336.66
+    const result = applyOperation("333.33", "multiply", 1);
+    expect(result).not.toBeNull();
+    // Check it's a valid number string with 2 decimals
+    expect(result).toMatch(/^-?\d+\.\d{2}$/);
+  });
+});
+
+describe("applyOperation — add (flat adjustment)", () => {
+  it("adds a positive flat amount", () => {
+    expect(applyOperation("1000.00", "add", 500)).toBe("1500.00");
+  });
+
+  it("subtracts a negative flat amount", () => {
+    expect(applyOperation("1000.00", "add", -200)).toBe("800.00");
+  });
+
+  it("returns null when oldValue is null", () => {
+    expect(applyOperation(null, "add", 500)).toBeNull();
+  });
+
+  it("handles zero operand (no change)", () => {
+    expect(applyOperation("3000.00", "add", 0)).toBe("3000.00");
+  });
+
+  it("handles adding to a negative value", () => {
+    expect(applyOperation("-1000.00", "add", 500)).toBe("-500.00");
+  });
+
+  it("handles large amounts without precision loss", () => {
+    expect(applyOperation("1234567.89", "add", 111111.11)).toBe("1345679.00");
+  });
+});


### PR DESCRIPTION
## Summary
- Editors/admins can open **Bulk Edit** from the data grid toolbar on any draft snapshot
- Panel: group selector, field toggle (Projected/Actual), operation toggle (% Change / Flat Adjust), numeric input
- **Preview** shows a before/after table for every affected cell (capped at 100 display rows) before any writes
- **Apply** commits all changes in a single Prisma transaction with a required audit reason
- **Undo** button appears after apply; sends the captured before-state back to `/api/values/bulk-restore` in a second transaction
- Locked snapshots: Bulk Edit button hidden (already guarded by `editable && !isLocked`)
- `applyOperation()` pure function: `multiply` uses `old × (1 + pct/100)`, `add` uses `old + flat`; null cells are skipped in both modes

## Review Findings
No findings yet — pending Codex review.

## Validation
- `npx tsc --noEmit` — clean
- `npx prettier --check .` — clean
- 12 unit tests: `applyOperation` covering multiply/add, null, zero, negative values, precision

## Tests
- `tests/unit/bulk-service.test.ts` — 12 tests for the `applyOperation` pure function
- HTTP handler validation (missing fields, invalid operation, preview mode, reason enforcement) follows established pattern; handler integration tests TBD per Codex review feedback

## Risk Check
- Medium: writes to the DB in a transaction; undo is client-side (lost on navigation — acceptable per phase scope)
- Auth: `requireEditorOrAbove` on both bulk endpoints; locked snapshot guard in UI
- No material-change threshold check on bulk ops (bulk is an explicit batch action with a required reason, which is the equivalent safeguard)

## Notes for Reviewer
- Closes #25
- Undo is single-use (button disabled after use) to avoid double-undo issues
- `bulkValueService.restore()` takes explicit `projectedAmount`/`actualAmount` tuples, so undo is field-scoped (doesn't clobber the other field)
- Codex: please review transaction safety in `BulkValueService.apply()` for very large batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)