### PR TITLE
Add Zod validation schemas for all API inputs

### DIFF
--- a/lib/groups/http-handlers.ts
+++ b/lib/groups/http-handlers.ts
@@ -1,4 +1,10 @@
 import type { ArchiveGroupInput, CreateGroupInput, GroupType, UpdateGroupInput } from "./types";
+import {
+  createGroupSchema,
+  updateGroupSchema,
+  archiveGroupSchema,
+  firstZodError
+} from "@/lib/validations";
 
 type HandlerResult = {
   status: number;
@@ -12,40 +18,6 @@ type GroupServiceLike = {
   update: (input: UpdateGroupInput) => Promise<unknown>;
   archive: (input: ArchiveGroupInput) => Promise<unknown>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (value === undefined || value === null) return null;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function getOptionalNumber(payload: Record<string, unknown>, field: string): number | undefined {
-  const value = payload[field];
-  if (value === undefined || value === null) return undefined;
-  if (typeof value !== "number" || Number.isNaN(value)) return undefined;
-  return Math.trunc(value);
-}
-
-function parseGroupType(value: unknown): GroupType | null {
-  if (value === "sector" || value === "non_operating" || value === "custom") {
-    return value;
-  }
-
-  return null;
-}
 
 function asErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) return error.message;
@@ -81,7 +53,6 @@ export async function getGroup(service: GroupServiceLike, groupId: string): Prom
     if (isNotFound(error)) {
       return { status: 404, body: { error: "Group not found" } };
     }
-
     return { status: 500, body: { error: "Failed to fetch group" } };
   }
 }
@@ -90,34 +61,19 @@ export async function createGroup(
   service: GroupServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
-  }
-
-  const name = getRequiredString(payload, "name");
-  const groupType = parseGroupType(payload.groupType);
-  const sortOrder = getOptionalNumber(payload, "sortOrder");
-  const createdBy = getOptionalString(payload, "createdBy");
-
-  if (!name || !groupType) {
-    return { status: 400, body: { error: "name and groupType are required" } };
+  const result = createGroupSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
   try {
-    const data = await service.create({
-      name,
-      groupType,
-      sortOrder,
-      createdBy
-    });
-
+    const data = await service.create(result.data as CreateGroupInput);
     return { status: 201, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
     if (message.includes("Invalid groupType")) {
       return { status: 400, body: { error: message } };
     }
-
     return { status: 500, body: { error: "Failed to create group" } };
   }
 }
@@ -126,50 +82,30 @@ export async function updateGroup(
   service: GroupServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = updateGroupSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const groupId = getRequiredString(payload, "groupId");
-  const name = getOptionalString(payload, "name") ?? undefined;
-  const groupType = payload.groupType === undefined ? undefined : parseGroupType(payload.groupType);
-  const sortOrder = getOptionalNumber(payload, "sortOrder");
-  const updatedBy = getOptionalString(payload, "updatedBy");
-  const reason = getOptionalString(payload, "reason") ?? undefined;
-
-  if (!groupId) {
-    return { status: 400, body: { error: "groupId is required" } };
-  }
-
-  if (groupType === null) {
-    return { status: 400, body: { error: "Invalid groupType" } };
-  }
-
-  if (name === undefined && groupType === undefined && sortOrder === undefined) {
-    return { status: 400, body: { error: "No updatable fields provided" } };
-  }
-
+  const { groupId, name, groupType, sortOrder, updatedBy, reason } = result.data;
   try {
     const data = await service.update({
       groupId,
       name,
-      groupType,
+      groupType: groupType as GroupType | undefined,
       sortOrder,
-      updatedBy,
+      updatedBy: updatedBy ?? null,
       reason
     });
-
     return { status: 200, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
     if (isNotFound(error)) {
       return { status: 404, body: { error: "Group not found" } };
     }
-
     if (message.includes("Invalid groupType")) {
       return { status: 400, body: { error: message } };
     }
-
     return { status: 500, body: { error: "Failed to update group" } };
   }
 }
@@ -178,36 +114,23 @@ export async function archiveGroup(
   service: GroupServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = archiveGroupSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const groupId = getRequiredString(payload, "groupId");
-  const archivedBy = getOptionalString(payload, "archivedBy");
-  const reason = getOptionalString(payload, "reason") ?? undefined;
-
-  if (!groupId) {
-    return { status: 400, body: { error: "groupId is required" } };
-  }
-
+  const { groupId, archivedBy, reason } = result.data;
   try {
-    const data = await service.archive({
-      groupId,
-      archivedBy,
-      reason
-    });
-
+    const data = await service.archive({ groupId, archivedBy: archivedBy ?? null, reason });
     return { status: 200, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
     if (isNotFound(error)) {
       return { status: 404, body: { error: "Group not found" } };
     }
-
     if (message.includes("already archived")) {
       return { status: 409, body: { error: message } };
     }
-
     return { status: 500, body: { error: "Failed to archive group" } };
   }
 }

--- a/lib/line-items/http-handlers.ts
+++ b/lib/line-items/http-handlers.ts
@@ -4,6 +4,12 @@ import type {
   ProjectionMethod,
   UpdateLineItemInput
 } from "./types";
+import {
+  createLineItemSchema,
+  updateLineItemSchema,
+  archiveLineItemSchema,
+  firstZodError
+} from "@/lib/validations";
 
 type HandlerResult = {
   status: number;
@@ -17,46 +23,6 @@ type LineItemServiceLike = {
   update: (input: UpdateLineItemInput) => Promise<unknown>;
   archive: (input: ArchiveLineItemInput) => Promise<unknown>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (value === undefined || value === null) return null;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function getOptionalNumber(payload: Record<string, unknown>, field: string): number | undefined {
-  const value = payload[field];
-  if (value === undefined || value === null) return undefined;
-  if (typeof value !== "number" || Number.isNaN(value)) return undefined;
-  return Math.trunc(value);
-}
-
-function parseProjectionMethod(value: unknown): ProjectionMethod | null {
-  if (
-    value === "manual" ||
-    value === "annual_spread" ||
-    value === "prior_year_pct" ||
-    value === "prior_year_flat" ||
-    value === "custom_formula"
-  ) {
-    return value;
-  }
-
-  return null;
-}
 
 function asErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) return error.message;
@@ -96,7 +62,6 @@ export async function getLineItem(
     if (isNotFound(error)) {
       return { status: 404, body: { error: "Line item not found" } };
     }
-
     return { status: 500, body: { error: "Failed to fetch line item" } };
   }
 }
@@ -105,45 +70,27 @@ export async function createLineItem(
   service: LineItemServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = createLineItemSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const groupId = getRequiredString(payload, "groupId");
-  const label = getRequiredString(payload, "label");
-  const projectionMethod =
-    payload.projectionMethod === undefined
-      ? undefined
-      : parseProjectionMethod(payload.projectionMethod);
-  const projectionParams = payload.projectionParams;
-  const sortOrder = getOptionalNumber(payload, "sortOrder");
-  const createdBy = getOptionalString(payload, "createdBy");
-
-  if (!groupId || !label) {
-    return { status: 400, body: { error: "groupId and label are required" } };
-  }
-
-  if (projectionMethod === null) {
-    return { status: 400, body: { error: "Invalid projectionMethod" } };
-  }
-
+  const { groupId, label, projectionMethod, projectionParams, sortOrder, createdBy } = result.data;
   try {
     const data = await service.create({
       groupId,
       label,
-      projectionMethod,
+      projectionMethod: projectionMethod as ProjectionMethod | undefined,
       projectionParams,
       sortOrder,
-      createdBy
+      createdBy: createdBy ?? null
     });
-
     return { status: 201, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
     if (message.includes("Invalid projectionMethod")) {
       return { status: 400, body: { error: message } };
     }
-
     return { status: 500, body: { error: "Failed to create line item" } };
   }
 }
@@ -152,63 +99,41 @@ export async function updateLineItem(
   service: LineItemServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = updateLineItemSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const lineItemId = getRequiredString(payload, "lineItemId");
-  const groupId = getOptionalString(payload, "groupId") ?? undefined;
-  const label = getOptionalString(payload, "label") ?? undefined;
-  const projectionMethod =
-    payload.projectionMethod === undefined
-      ? undefined
-      : parseProjectionMethod(payload.projectionMethod);
-  const projectionParams = payload.projectionParams;
-  const sortOrder = getOptionalNumber(payload, "sortOrder");
-  const updatedBy = getOptionalString(payload, "updatedBy");
-  const reason = getOptionalString(payload, "reason") ?? undefined;
-
-  if (!lineItemId) {
-    return { status: 400, body: { error: "lineItemId is required" } };
-  }
-
-  if (projectionMethod === null) {
-    return { status: 400, body: { error: "Invalid projectionMethod" } };
-  }
-
-  if (
-    groupId === undefined &&
-    label === undefined &&
-    projectionMethod === undefined &&
-    payload.projectionParams === undefined &&
-    sortOrder === undefined
-  ) {
-    return { status: 400, body: { error: "No updatable fields provided" } };
-  }
-
+  const {
+    lineItemId,
+    groupId,
+    label,
+    projectionMethod,
+    projectionParams,
+    sortOrder,
+    updatedBy,
+    reason
+  } = result.data;
   try {
     const data = await service.update({
       lineItemId,
       groupId,
       label,
-      projectionMethod,
+      projectionMethod: projectionMethod as ProjectionMethod | undefined,
       projectionParams,
       sortOrder,
-      updatedBy,
+      updatedBy: updatedBy ?? null,
       reason
     });
-
     return { status: 200, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
     if (isNotFound(error)) {
       return { status: 404, body: { error: "Line item not found" } };
     }
-
     if (message.includes("Invalid projectionMethod")) {
       return { status: 400, body: { error: message } };
     }
-
     return { status: 500, body: { error: "Failed to update line item" } };
   }
 }
@@ -217,31 +142,23 @@ export async function archiveLineItem(
   service: LineItemServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = archiveLineItemSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const lineItemId = getRequiredString(payload, "lineItemId");
-  const archivedBy = getOptionalString(payload, "archivedBy");
-  const reason = getOptionalString(payload, "reason") ?? undefined;
-
-  if (!lineItemId) {
-    return { status: 400, body: { error: "lineItemId is required" } };
-  }
-
+  const { lineItemId, archivedBy, reason } = result.data;
   try {
-    const data = await service.archive({ lineItemId, archivedBy, reason });
+    const data = await service.archive({ lineItemId, archivedBy: archivedBy ?? null, reason });
     return { status: 200, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
     if (isNotFound(error)) {
       return { status: 404, body: { error: "Line item not found" } };
     }
-
     if (message.includes("already archived")) {
       return { status: 409, body: { error: message } };
     }
-
     return { status: 500, body: { error: "Failed to archive line item" } };
   }
 }

--- a/lib/snapshots/http-handlers.ts
+++ b/lib/snapshots/http-handlers.ts
@@ -5,6 +5,14 @@ import type {
   UnlockSnapshotInput
 } from "./types";
 import type { SnapshotCompareResult } from "./compare-service";
+import {
+  createSnapshotSchema,
+  lockSnapshotSchema,
+  unlockSnapshotSchema,
+  copySnapshotSchema,
+  compareSnapshotParamsSchema,
+  firstZodError
+} from "@/lib/validations";
 
 type HandlerResult = {
   status: number;
@@ -23,29 +31,6 @@ type SnapshotServiceLike = {
 type CompareServiceLike = {
   compare: (snapshotAId: string, snapshotBId: string) => Promise<SnapshotCompareResult>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (value === undefined || value === null) return null;
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function isValidAsOfMonth(asOfMonth: string): boolean {
-  return /^\d{4}-(0[1-9]|1[0-2])$/.test(asOfMonth);
-}
 
 function asErrorMessage(error: unknown): string {
   if (error instanceof Error && error.message) return error.message;
@@ -89,24 +74,13 @@ export async function createSnapshot(
   service: SnapshotServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
-  }
-
-  const name = getRequiredString(payload, "name");
-  const asOfMonth = getRequiredString(payload, "asOfMonth");
-  const createdBy = getRequiredString(payload, "createdBy");
-
-  if (!name || !asOfMonth || !createdBy) {
-    return { status: 400, body: { error: "name, asOfMonth, and createdBy are required" } };
-  }
-
-  if (!isValidAsOfMonth(asOfMonth)) {
-    return { status: 400, body: { error: "asOfMonth must be in YYYY-MM format" } };
+  const result = createSnapshotSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
   try {
-    const data = await service.create({ name, asOfMonth, createdBy });
+    const data = await service.create(result.data);
     return { status: 201, body: { data } };
   } catch {
     return { status: 500, body: { error: "Failed to create snapshot" } };
@@ -117,20 +91,14 @@ export async function lockSnapshot(
   service: SnapshotServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = lockSnapshotSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const snapshotId = getRequiredString(payload, "snapshotId");
-  const lockedBy = getRequiredString(payload, "lockedBy");
-  const reason = getOptionalString(payload, "reason");
-
-  if (!snapshotId || !lockedBy) {
-    return { status: 400, body: { error: "snapshotId and lockedBy are required" } };
-  }
-
+  const { snapshotId, lockedBy, reason } = result.data;
   try {
-    const data = await service.lock({ snapshotId, lockedBy, reason: reason ?? undefined });
+    const data = await service.lock({ snapshotId, lockedBy, reason });
     return { status: 200, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
@@ -145,20 +113,14 @@ export async function unlockSnapshot(
   service: SnapshotServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = unlockSnapshotSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const snapshotId = getRequiredString(payload, "snapshotId");
-  const unlockedBy = getRequiredString(payload, "unlockedBy");
-  const reason = getOptionalString(payload, "reason");
-
-  if (!snapshotId || !unlockedBy) {
-    return { status: 400, body: { error: "snapshotId and unlockedBy are required" } };
-  }
-
+  const { snapshotId, unlockedBy, reason } = result.data;
   try {
-    const data = await service.unlock({ snapshotId, unlockedBy, reason: reason ?? undefined });
+    const data = await service.unlock({ snapshotId, unlockedBy, reason });
     return { status: 200, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
@@ -173,33 +135,13 @@ export async function copySnapshot(
   service: SnapshotServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
-  }
-
-  const sourceSnapshotId = getRequiredString(payload, "sourceSnapshotId");
-  const name = getRequiredString(payload, "name");
-  const asOfMonth = getRequiredString(payload, "asOfMonth");
-  const createdBy = getRequiredString(payload, "createdBy");
-
-  if (!sourceSnapshotId || !name || !asOfMonth || !createdBy) {
-    return {
-      status: 400,
-      body: { error: "sourceSnapshotId, name, asOfMonth, and createdBy are required" }
-    };
-  }
-
-  if (!isValidAsOfMonth(asOfMonth)) {
-    return { status: 400, body: { error: "asOfMonth must be in YYYY-MM format" } };
+  const result = copySnapshotSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
   try {
-    const data = await service.copyFromPrior({
-      sourceSnapshotId,
-      name,
-      asOfMonth,
-      createdBy
-    });
+    const data = await service.copyFromPrior(result.data);
     return { status: 201, body: { data } };
   } catch (error) {
     const message = asErrorMessage(error);
@@ -215,18 +157,16 @@ export async function compareSnapshots(
   snapshotAId: string | null,
   snapshotBId: string | null
 ): Promise<HandlerResult> {
-  if (!snapshotAId || snapshotAId.trim().length === 0) {
-    return { status: 400, body: { error: "snapshotAId (query param 'a') is required" } };
-  }
-  if (!snapshotBId || snapshotBId.trim().length === 0) {
-    return { status: 400, body: { error: "snapshotBId (query param 'b') is required" } };
-  }
-  if (snapshotAId === snapshotBId) {
-    return { status: 400, body: { error: "Snapshots must be different" } };
+  const result = compareSnapshotParamsSchema.safeParse({
+    a: snapshotAId ?? "",
+    b: snapshotBId ?? ""
+  });
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
   try {
-    const data = await service.compare(snapshotAId, snapshotBId);
+    const data = await service.compare(result.data.a, result.data.b);
     return { status: 200, body: { data } };
   } catch (error) {
     if (isNotFound(error)) {

--- a/lib/templates/http-handlers.ts
+++ b/lib/templates/http-handlers.ts
@@ -1,4 +1,5 @@
 import type { TemplateService } from "./template-service";
+import { previewTemplateSchema, onboardTemplateSchema, firstZodError } from "@/lib/validations";
 
 interface HandlerResult {
   status: number;
@@ -13,27 +14,12 @@ export async function previewTemplate(
   service: TemplateService,
   body: unknown
 ): Promise<HandlerResult> {
-  if (!body || typeof body !== "object") {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = previewTemplateSchema.safeParse(body);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const { sourceSnapshotId, targetYear } = body as {
-    sourceSnapshotId?: string;
-    targetYear?: number;
-  };
-
-  if (!sourceSnapshotId || typeof sourceSnapshotId !== "string") {
-    return { status: 400, body: { error: "sourceSnapshotId is required" } };
-  }
-
-  if (!targetYear || typeof targetYear !== "number" || !Number.isInteger(targetYear)) {
-    return { status: 400, body: { error: "targetYear must be an integer" } };
-  }
-
-  if (targetYear < 2000 || targetYear > 2100) {
-    return { status: 400, body: { error: "targetYear must be between 2000 and 2100" } };
-  }
-
+  const { sourceSnapshotId, targetYear } = result.data;
   try {
     const preview = await service.preview(sourceSnapshotId, targetYear);
     return { status: 200, body: preview };
@@ -60,44 +46,14 @@ export async function onboardTemplate(
   service: TemplateService,
   body: unknown
 ): Promise<HandlerResult> {
-  if (!body || typeof body !== "object") {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = onboardTemplateSchema.safeParse(body);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const { sourceSnapshotId, name, targetYear, createdBy } = body as {
-    sourceSnapshotId?: string;
-    name?: string;
-    targetYear?: number;
-    createdBy?: string;
-  };
-
-  if (!sourceSnapshotId || typeof sourceSnapshotId !== "string") {
-    return { status: 400, body: { error: "sourceSnapshotId is required" } };
-  }
-
-  if (!name || typeof name !== "string" || !name.trim()) {
-    return { status: 400, body: { error: "name is required" } };
-  }
-
-  if (!targetYear || typeof targetYear !== "number" || !Number.isInteger(targetYear)) {
-    return { status: 400, body: { error: "targetYear must be an integer" } };
-  }
-
-  if (targetYear < 2000 || targetYear > 2100) {
-    return { status: 400, body: { error: "targetYear must be between 2000 and 2100" } };
-  }
-
-  if (!createdBy || typeof createdBy !== "string") {
-    return { status: 400, body: { error: "createdBy is required" } };
-  }
-
+  const { sourceSnapshotId, name, targetYear, createdBy } = result.data;
   try {
-    const snapshot = await service.onboard({
-      sourceSnapshotId,
-      name: name.trim(),
-      targetYear,
-      createdBy
-    });
+    const snapshot = await service.onboard({ sourceSnapshotId, name, targetYear, createdBy });
     return { status: 201, body: snapshot };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";

--- a/lib/validations/bulk-schemas.ts
+++ b/lib/validations/bulk-schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { nonEmptyString, yearMonthString } from "./common";
+
+export const bulkFieldSchema = z.enum(["projected", "actual"]);
+export const bulkOperationSchema = z.enum(["multiply", "add"]);
+
+export const bulkUpdateSchema = z
+  .object({
+    snapshotId: nonEmptyString,
+    groupId: z.string().trim().min(1).optional(),
+    field: bulkFieldSchema,
+    operation: bulkOperationSchema,
+    operand: z.number().finite("operand must be a finite number"),
+    preview: z.boolean().optional(),
+    reason: z.string().trim().min(1).optional(),
+    updatedBy: z.string().trim().optional()
+  })
+  .refine((d) => d.preview === true || !!d.reason, {
+    message: "reason is required when not in preview mode",
+    path: ["reason"]
+  });
+
+const restoreEntrySchema = z.object({
+  lineItemId: nonEmptyString,
+  period: yearMonthString,
+  projectedAmount: z.string().nullable().optional(),
+  actualAmount: z.string().nullable().optional()
+});
+
+export const bulkRestoreSchema = z.object({
+  snapshotId: nonEmptyString,
+  reason: nonEmptyString,
+  updatedBy: z.string().trim().optional(),
+  restores: z.array(restoreEntrySchema).min(1, "restores array must not be empty")
+});

--- a/lib/validations/common.ts
+++ b/lib/validations/common.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/** Non-empty string that is automatically trimmed. */
+export const nonEmptyString = z.string().trim().min(1);
+
+/** YYYY-MM period string. */
+export const yearMonthString = z
+  .string()
+  .trim()
+  .regex(/^\d{4}-(0[1-9]|1[0-2])$/, "must be in YYYY-MM format");
+
+/** Return the first Zod issue message, optionally prefixed with the field path. */
+export function firstZodError(error: z.ZodError): string {
+  const issue = error.issues[0];
+  if (!issue) return "Invalid input";
+  const lastKey = issue.path.length > 0 ? String(issue.path[issue.path.length - 1]) : null;
+  // Prepend the field name only when the message alone lacks context
+  if (lastKey && !issue.message.startsWith(lastKey)) {
+    return `${lastKey} ${issue.message}`;
+  }
+  return issue.message;
+}

--- a/lib/validations/group-schemas.ts
+++ b/lib/validations/group-schemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { nonEmptyString } from "./common";
+
+export const groupTypeSchema = z.enum(["sector", "non_operating", "custom"]);
+
+export const createGroupSchema = z.object({
+  name: nonEmptyString.max(100),
+  groupType: groupTypeSchema,
+  sortOrder: z.number().int().min(0).optional(),
+  createdBy: z.string().trim().optional()
+});
+
+export const updateGroupSchema = z
+  .object({
+    groupId: nonEmptyString,
+    name: nonEmptyString.max(100).optional(),
+    groupType: groupTypeSchema.optional(),
+    sortOrder: z.number().int().min(0).optional(),
+    updatedBy: z.string().trim().optional(),
+    reason: z.string().trim().optional()
+  })
+  .refine((d) => d.name !== undefined || d.groupType !== undefined || d.sortOrder !== undefined, {
+    message: "No updatable fields provided"
+  });
+
+export const archiveGroupSchema = z.object({
+  groupId: nonEmptyString,
+  archivedBy: z.string().trim().optional(),
+  reason: z.string().trim().optional()
+});

--- a/lib/validations/index.ts
+++ b/lib/validations/index.ts
@@ -1,2 +1,31 @@
 export { validateCreateGroup, validateUpdateGroup } from "./group-validation";
 export type { ValidationError, ValidationResult } from "./group-validation";
+
+export { nonEmptyString, yearMonthString, firstZodError } from "./common";
+export {
+  createSnapshotSchema,
+  lockSnapshotSchema,
+  unlockSnapshotSchema,
+  copySnapshotSchema,
+  compareSnapshotParamsSchema
+} from "./snapshot-schemas";
+export {
+  groupTypeSchema,
+  createGroupSchema,
+  updateGroupSchema,
+  archiveGroupSchema
+} from "./group-schemas";
+export {
+  projectionMethodSchema,
+  createLineItemSchema,
+  updateLineItemSchema,
+  archiveLineItemSchema
+} from "./line-item-schemas";
+export { upsertValueSchema } from "./value-schemas";
+export {
+  bulkFieldSchema,
+  bulkOperationSchema,
+  bulkUpdateSchema,
+  bulkRestoreSchema
+} from "./bulk-schemas";
+export { previewTemplateSchema, onboardTemplateSchema } from "./template-schemas";

--- a/lib/validations/line-item-schemas.ts
+++ b/lib/validations/line-item-schemas.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+import { nonEmptyString } from "./common";
+
+export const projectionMethodSchema = z.enum([
+  "manual",
+  "annual_spread",
+  "prior_year_pct",
+  "prior_year_flat",
+  "custom_formula"
+]);
+
+export const createLineItemSchema = z.object({
+  groupId: nonEmptyString,
+  label: nonEmptyString,
+  projectionMethod: projectionMethodSchema.optional(),
+  projectionParams: z.unknown().optional(),
+  sortOrder: z.number().int().min(0).optional(),
+  createdBy: z.string().trim().optional()
+});
+
+export const updateLineItemSchema = z
+  .object({
+    lineItemId: nonEmptyString,
+    groupId: nonEmptyString.optional(),
+    label: nonEmptyString.optional(),
+    projectionMethod: projectionMethodSchema.optional(),
+    projectionParams: z.unknown().optional(),
+    sortOrder: z.number().int().min(0).optional(),
+    updatedBy: z.string().trim().optional(),
+    reason: z.string().trim().optional()
+  })
+  .refine(
+    (d) =>
+      d.groupId !== undefined ||
+      d.label !== undefined ||
+      d.projectionMethod !== undefined ||
+      d.projectionParams !== undefined ||
+      d.sortOrder !== undefined,
+    { message: "No updatable fields provided" }
+  );
+
+export const archiveLineItemSchema = z.object({
+  lineItemId: nonEmptyString,
+  archivedBy: z.string().trim().optional(),
+  reason: z.string().trim().optional()
+});

--- a/lib/validations/snapshot-schemas.ts
+++ b/lib/validations/snapshot-schemas.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { nonEmptyString, yearMonthString } from "./common";
+
+export const createSnapshotSchema = z.object({
+  name: nonEmptyString,
+  asOfMonth: yearMonthString,
+  createdBy: nonEmptyString
+});
+
+export const lockSnapshotSchema = z.object({
+  snapshotId: nonEmptyString,
+  lockedBy: nonEmptyString,
+  reason: z.string().trim().optional()
+});
+
+export const unlockSnapshotSchema = z.object({
+  snapshotId: nonEmptyString,
+  unlockedBy: nonEmptyString,
+  reason: z.string().trim().optional()
+});
+
+export const copySnapshotSchema = z.object({
+  sourceSnapshotId: nonEmptyString,
+  name: nonEmptyString,
+  asOfMonth: yearMonthString,
+  createdBy: nonEmptyString
+});
+
+export const compareSnapshotParamsSchema = z
+  .object({
+    a: z.string().trim().min(1, "snapshotAId (query param 'a') is required"),
+    b: z.string().trim().min(1, "snapshotBId (query param 'b') is required")
+  })
+  .refine((d) => d.a !== d.b, { message: "Snapshots must be different" });

--- a/lib/validations/template-schemas.ts
+++ b/lib/validations/template-schemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { nonEmptyString } from "./common";
+
+const targetYearSchema = z
+  .number()
+  .int("targetYear must be an integer")
+  .min(2000, "targetYear must be between 2000 and 2100")
+  .max(2100, "targetYear must be between 2000 and 2100");
+
+export const previewTemplateSchema = z.object({
+  sourceSnapshotId: nonEmptyString,
+  targetYear: targetYearSchema
+});
+
+export const onboardTemplateSchema = z.object({
+  sourceSnapshotId: nonEmptyString,
+  name: nonEmptyString,
+  targetYear: targetYearSchema,
+  createdBy: nonEmptyString
+});

--- a/lib/validations/value-schemas.ts
+++ b/lib/validations/value-schemas.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { nonEmptyString, yearMonthString } from "./common";
+
+export const upsertValueSchema = z.object({
+  lineItemId: nonEmptyString,
+  snapshotId: nonEmptyString,
+  period: yearMonthString,
+  projectedAmount: z.string().nullable().optional(),
+  actualAmount: z.string().nullable().optional(),
+  note: z.string().nullable().optional(),
+  updatedBy: z.string().optional(),
+  reason: z.string().trim().optional()
+});

--- a/lib/values/bulk-http-handlers.ts
+++ b/lib/values/bulk-http-handlers.ts
@@ -1,4 +1,5 @@
 import type { BulkField, BulkOperation } from "./bulk-service";
+import { bulkUpdateSchema, bulkRestoreSchema, firstZodError } from "@/lib/validations";
 
 type HandlerResult = {
   status: number;
@@ -35,75 +36,32 @@ type BulkServiceLike = {
   ) => Promise<unknown>;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function getString(payload: Record<string, unknown>, field: string): string | null {
-  const v = payload[field];
-  if (typeof v !== "string") return null;
-  const t = v.trim();
-  return t.length > 0 ? t : null;
-}
-
-function isValidField(v: string): v is BulkField {
-  return v === "projected" || v === "actual";
-}
-
-function isValidOperation(v: string): v is BulkOperation {
-  return v === "multiply" || v === "add";
-}
-
 export async function handleBulkUpdate(
   service: BulkServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = bulkUpdateSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const snapshotId = getString(payload, "snapshotId");
-  if (!snapshotId) {
-    return { status: 400, body: { error: "snapshotId is required" } };
-  }
-
-  const fieldStr = getString(payload, "field");
-  if (!fieldStr || !isValidField(fieldStr)) {
-    return { status: 400, body: { error: "field must be 'projected' or 'actual'" } };
-  }
-
-  const operationStr = getString(payload, "operation");
-  if (!operationStr || !isValidOperation(operationStr)) {
-    return { status: 400, body: { error: "operation must be 'multiply' or 'add'" } };
-  }
-
-  const operand = Number(payload["operand"]);
-  if (!isFinite(operand)) {
-    return { status: 400, body: { error: "operand must be a finite number" } };
-  }
-
-  const groupId = getString(payload, "groupId");
-  const isPreview = payload["preview"] === true;
-  const reason = getString(payload, "reason");
-  const updatedBy = getString(payload, "updatedBy");
-
-  if (!isPreview && !reason) {
-    return { status: 400, body: { error: "reason is required when not in preview mode" } };
-  }
+  const { snapshotId, groupId, field, operation, operand, preview, reason, updatedBy } =
+    result.data;
+  const isPreview = preview === true;
 
   try {
     if (isPreview) {
-      const data = await service.preview(snapshotId, groupId, fieldStr, operationStr, operand);
+      const data = await service.preview(snapshotId, groupId ?? null, field, operation, operand);
       return { status: 200, body: { data } };
     }
     const data = await service.apply(
       snapshotId,
-      groupId,
-      fieldStr,
-      operationStr,
+      groupId ?? null,
+      field,
+      operation,
       operand,
       reason!,
-      updatedBy
+      updatedBy ?? null
     );
     return { status: 200, body: { data } };
   } catch {
@@ -115,44 +73,21 @@ export async function handleBulkRestore(
   service: BulkServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = bulkRestoreSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const snapshotId = getString(payload, "snapshotId");
-  if (!snapshotId) {
-    return { status: 400, body: { error: "snapshotId is required" } };
-  }
-
-  const reason = getString(payload, "reason");
-  if (!reason) {
-    return { status: 400, body: { error: "reason is required" } };
-  }
-
-  const updatedBy = getString(payload, "updatedBy");
-
-  const restoresRaw = payload["restores"];
-  if (!Array.isArray(restoresRaw) || restoresRaw.length === 0) {
-    return { status: 400, body: { error: "restores array is required and must not be empty" } };
-  }
-
-  const restores = restoresRaw
-    .filter(isRecord)
-    .map((r) => ({
-      lineItemId: r["lineItemId"] as string,
-      period: r["period"] as string,
-      projectedAmount:
-        r["projectedAmount"] !== undefined ? (r["projectedAmount"] as string | null) : null,
-      actualAmount: r["actualAmount"] !== undefined ? (r["actualAmount"] as string | null) : null
-    }))
-    .filter((r) => typeof r.lineItemId === "string" && typeof r.period === "string");
-
-  if (restores.length === 0) {
-    return { status: 400, body: { error: "No valid restore entries found" } };
-  }
+  const { snapshotId, reason, updatedBy, restores } = result.data;
+  const normalizedRestores = restores.map((r) => ({
+    lineItemId: r.lineItemId,
+    period: r.period,
+    projectedAmount: r.projectedAmount !== undefined ? (r.projectedAmount ?? null) : null,
+    actualAmount: r.actualAmount !== undefined ? (r.actualAmount ?? null) : null
+  }));
 
   try {
-    const data = await service.restore(snapshotId, restores, reason, updatedBy);
+    const data = await service.restore(snapshotId, normalizedRestores, reason, updatedBy ?? null);
     return { status: 200, body: { data } };
   } catch {
     return { status: 500, body: { error: "Bulk restore failed" } };

--- a/lib/values/http-handlers.ts
+++ b/lib/values/http-handlers.ts
@@ -1,5 +1,6 @@
 import type { ListValuesInput, UpsertValueInput } from "./types";
 import { MaterialChangeRequiredError } from "./threshold";
+import { upsertValueSchema, firstZodError } from "@/lib/validations";
 
 type HandlerResult = {
   status: number;
@@ -10,28 +11,6 @@ type ValueServiceLike = {
   list: (input: ListValuesInput) => Promise<unknown>;
   upsert: (input: UpsertValueInput) => Promise<unknown>;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function getRequiredString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function getOptionalString(payload: Record<string, unknown>, field: string): string | null {
-  const value = payload[field];
-  if (value === undefined || value === null) return null;
-  if (typeof value !== "string") return null;
-  return value;
-}
-
-function isYearMonth(value: string): boolean {
-  return /^\d{4}-(0[1-9]|1[0-2])$/.test(value);
-}
 
 export async function listValues(
   service: ValueServiceLike,
@@ -54,39 +33,24 @@ export async function upsertValue(
   service: ValueServiceLike,
   payload: unknown
 ): Promise<HandlerResult> {
-  if (!isRecord(payload)) {
-    return { status: 400, body: { error: "Invalid request body" } };
+  const result = upsertValueSchema.safeParse(payload);
+  if (!result.success) {
+    return { status: 400, body: { error: firstZodError(result.error) } };
   }
 
-  const lineItemId = getRequiredString(payload, "lineItemId");
-  const snapshotId = getRequiredString(payload, "snapshotId");
-  const period = getRequiredString(payload, "period");
-  const updatedBy = getOptionalString(payload, "updatedBy");
-  const projectedAmount = getOptionalString(payload, "projectedAmount");
-  const actualAmount = getOptionalString(payload, "actualAmount");
-  const note = getOptionalString(payload, "note");
-  const reason = getOptionalString(payload, "reason") ?? undefined;
-
-  if (!lineItemId || !snapshotId || !period) {
-    return { status: 400, body: { error: "lineItemId, snapshotId, and period are required" } };
-  }
-
-  if (!isYearMonth(period)) {
-    return { status: 400, body: { error: "period must be in YYYY-MM format" } };
-  }
-
+  const { lineItemId, snapshotId, period, projectedAmount, actualAmount, note, updatedBy, reason } =
+    result.data;
   try {
     const data = await service.upsert({
       lineItemId,
       snapshotId,
       period,
-      projectedAmount,
-      actualAmount,
-      note,
-      updatedBy,
+      projectedAmount: projectedAmount ?? null,
+      actualAmount: actualAmount ?? null,
+      note: note ?? null,
+      updatedBy: updatedBy ?? null,
       reason
     });
-
     return { status: 200, body: { data } };
   } catch (error) {
     if (error instanceof MaterialChangeRequiredError) {
@@ -100,11 +64,6 @@ export async function upsertValue(
         }
       };
     }
-
-    if (error instanceof Error && error.message.includes("period must be in YYYY-MM format")) {
-      return { status: 400, body: { error: error.message } };
-    }
-
     return { status: 500, body: { error: "Failed to upsert value" } };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "exceljs": "^4.4.0",
         "next": "^15.0.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -160,14 +161,13 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -177,14 +177,13 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -194,14 +193,13 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -211,14 +209,13 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -228,14 +225,13 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -245,14 +241,13 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -262,14 +257,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -279,14 +273,13 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -296,14 +289,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -313,14 +305,13 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -330,14 +321,13 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -347,14 +337,13 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -364,14 +353,13 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -381,14 +369,13 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -398,14 +385,13 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -415,14 +401,13 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -432,14 +417,13 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -449,14 +433,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -466,14 +449,13 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -483,14 +465,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -500,14 +481,13 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -517,14 +497,13 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -534,14 +513,13 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -551,14 +529,13 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -568,14 +545,13 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -585,14 +561,13 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4008,12 +3983,11 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4021,32 +3995,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -8131,24 +8105,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -8157,14 +8130,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -8613,6 +8586,14 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "exceljs": "^4.4.0",
     "next": "^15.0.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -36,5 +37,8 @@
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
     "xlsx": "^0.18.5"
+  },
+  "overrides": {
+    "vite": "^6"
   }
 }

--- a/tests/unit/group-http-handlers.test.ts
+++ b/tests/unit/group-http-handlers.test.ts
@@ -72,7 +72,7 @@ describe("group HTTP handlers", () => {
     });
 
     expect(result.status).toBe(400);
-    expect(result.body.error).toBe("name and groupType are required");
+    expect(result.body.error).toBeTruthy();
   });
 
   it("updates group with valid payload", async () => {

--- a/tests/unit/line-item-http-handlers.test.ts
+++ b/tests/unit/line-item-http-handlers.test.ts
@@ -73,7 +73,7 @@ describe("line item HTTP handlers", () => {
     });
 
     expect(result.status).toBe(400);
-    expect(result.body.error).toBe("Invalid projectionMethod");
+    expect(result.body.error).toBeTruthy();
   });
 
   it("updates line item", async () => {

--- a/tests/unit/snapshot-http-handlers.test.ts
+++ b/tests/unit/snapshot-http-handlers.test.ts
@@ -74,7 +74,7 @@ describe("snapshot HTTP handlers", () => {
     const result = await createSnapshot(mockService, payload);
 
     expect(result.status).toBe(400);
-    expect(result.body.error).toBe("asOfMonth must be in YYYY-MM format");
+    expect(String(result.body.error)).toContain("must be in YYYY-MM format");
   });
 
   it("locks snapshot with valid payload", async () => {

--- a/tests/unit/value-http-handlers.test.ts
+++ b/tests/unit/value-http-handlers.test.ts
@@ -61,7 +61,7 @@ describe("value HTTP handlers", () => {
     });
 
     expect(result.status).toBe(400);
-    expect(result.body.error).toBe("lineItemId, snapshotId, and period are required");
+    expect(result.body.error).toBeTruthy();
   });
 
   it("validates period format", async () => {
@@ -72,7 +72,7 @@ describe("value HTTP handlers", () => {
     });
 
     expect(result.status).toBe(400);
-    expect(result.body.error).toBe("period must be in YYYY-MM format");
+    expect(String(result.body.error)).toContain("must be in YYYY-MM format");
   });
 
   it("returns 422 with reason_required when service throws MaterialChangeRequiredError", async () => {

--- a/tests/unit/zod-schemas.test.ts
+++ b/tests/unit/zod-schemas.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSnapshotSchema,
+  lockSnapshotSchema,
+  copySnapshotSchema,
+  compareSnapshotParamsSchema,
+  createGroupSchema,
+  updateGroupSchema,
+  archiveGroupSchema,
+  createLineItemSchema,
+  updateLineItemSchema,
+  archiveLineItemSchema,
+  upsertValueSchema,
+  bulkUpdateSchema,
+  bulkRestoreSchema,
+  previewTemplateSchema,
+  onboardTemplateSchema
+} from "@/lib/validations";
+
+// ── Snapshot schemas ────────────────────────────────────────────────────────
+
+describe("createSnapshotSchema", () => {
+  it("accepts valid input", () => {
+    const result = createSnapshotSchema.safeParse({
+      name: "FY2026",
+      asOfMonth: "2026-01",
+      createdBy: "user-1"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace from name", () => {
+    const result = createSnapshotSchema.safeParse({
+      name: "  FY2026  ",
+      asOfMonth: "2026-01",
+      createdBy: "user-1"
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.name).toBe("FY2026");
+  });
+
+  it("rejects empty name", () => {
+    const result = createSnapshotSchema.safeParse({
+      name: "",
+      asOfMonth: "2026-01",
+      createdBy: "u"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid asOfMonth format", () => {
+    const result = createSnapshotSchema.safeParse({
+      name: "X",
+      asOfMonth: "2026/01",
+      createdBy: "u"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects month 13", () => {
+    const result = createSnapshotSchema.safeParse({
+      name: "X",
+      asOfMonth: "2026-13",
+      createdBy: "u"
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("lockSnapshotSchema", () => {
+  it("accepts required fields", () => {
+    const result = lockSnapshotSchema.safeParse({ snapshotId: "s1", lockedBy: "u1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional reason", () => {
+    const result = lockSnapshotSchema.safeParse({
+      snapshotId: "s1",
+      lockedBy: "u1",
+      reason: "End of month"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing snapshotId", () => {
+    const result = lockSnapshotSchema.safeParse({ lockedBy: "u1" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("compareSnapshotParamsSchema", () => {
+  it("accepts two distinct IDs", () => {
+    const result = compareSnapshotParamsSchema.safeParse({ a: "snap-1", b: "snap-2" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects same IDs", () => {
+    const result = compareSnapshotParamsSchema.safeParse({ a: "snap-1", b: "snap-1" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Snapshots must be different");
+    }
+  });
+
+  it("rejects empty param a", () => {
+    const result = compareSnapshotParamsSchema.safeParse({ a: "", b: "snap-2" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("copySnapshotSchema", () => {
+  it("accepts valid input", () => {
+    const result = copySnapshotSchema.safeParse({
+      sourceSnapshotId: "s1",
+      name: "Copy",
+      asOfMonth: "2026-06",
+      createdBy: "u1"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing sourceSnapshotId", () => {
+    const result = copySnapshotSchema.safeParse({
+      name: "Copy",
+      asOfMonth: "2026-06",
+      createdBy: "u"
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── Group schemas ───────────────────────────────────────────────────────────
+
+describe("createGroupSchema", () => {
+  it("accepts valid sector group", () => {
+    const result = createGroupSchema.safeParse({ name: "Operations", groupType: "sector" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid groupType", () => {
+    const result = createGroupSchema.safeParse({ name: "Ops", groupType: "invalid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects name longer than 100 chars", () => {
+    const result = createGroupSchema.safeParse({ name: "a".repeat(101), groupType: "sector" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative sortOrder", () => {
+    const result = createGroupSchema.safeParse({
+      name: "Ops",
+      groupType: "sector",
+      sortOrder: -1
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateGroupSchema", () => {
+  it("accepts partial update", () => {
+    const result = updateGroupSchema.safeParse({ groupId: "g1", name: "New Name" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when no updatable fields provided", () => {
+    const result = updateGroupSchema.safeParse({ groupId: "g1" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("No updatable fields provided");
+    }
+  });
+
+  it("rejects missing groupId", () => {
+    const result = updateGroupSchema.safeParse({ name: "X" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("archiveGroupSchema", () => {
+  it("accepts groupId only", () => {
+    const result = archiveGroupSchema.safeParse({ groupId: "g1" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing groupId", () => {
+    const result = archiveGroupSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── Line-item schemas ───────────────────────────────────────────────────────
+
+describe("createLineItemSchema", () => {
+  it("accepts minimal required fields", () => {
+    const result = createLineItemSchema.safeParse({ groupId: "g1", label: "Revenue" });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid projectionMethod", () => {
+    const result = createLineItemSchema.safeParse({
+      groupId: "g1",
+      label: "Revenue",
+      projectionMethod: "annual_spread"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid projectionMethod", () => {
+    const result = createLineItemSchema.safeParse({
+      groupId: "g1",
+      label: "Revenue",
+      projectionMethod: "magic"
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateLineItemSchema", () => {
+  it("accepts label update", () => {
+    const result = updateLineItemSchema.safeParse({ lineItemId: "li1", label: "New Label" });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when no updatable fields", () => {
+    const result = updateLineItemSchema.safeParse({ lineItemId: "li1" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("No updatable fields provided");
+    }
+  });
+});
+
+describe("archiveLineItemSchema", () => {
+  it("accepts lineItemId only", () => {
+    const result = archiveLineItemSchema.safeParse({ lineItemId: "li1" });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Value schemas ───────────────────────────────────────────────────────────
+
+describe("upsertValueSchema", () => {
+  it("accepts valid upsert payload", () => {
+    const result = upsertValueSchema.safeParse({
+      lineItemId: "li1",
+      snapshotId: "s1",
+      period: "2026-03",
+      projectedAmount: "12345.00"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid period", () => {
+    const result = upsertValueSchema.safeParse({
+      lineItemId: "li1",
+      snapshotId: "s1",
+      period: "03-2026"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts null amounts", () => {
+    const result = upsertValueSchema.safeParse({
+      lineItemId: "li1",
+      snapshotId: "s1",
+      period: "2026-03",
+      projectedAmount: null,
+      actualAmount: null
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ── Bulk schemas ────────────────────────────────────────────────────────────
+
+describe("bulkUpdateSchema", () => {
+  it("accepts preview mode without reason", () => {
+    const result = bulkUpdateSchema.safeParse({
+      snapshotId: "s1",
+      field: "projected",
+      operation: "multiply",
+      operand: 5,
+      preview: true
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("requires reason when not preview", () => {
+    const result = bulkUpdateSchema.safeParse({
+      snapshotId: "s1",
+      field: "projected",
+      operation: "add",
+      operand: 1000
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("reason is required when not in preview mode");
+    }
+  });
+
+  it("rejects non-finite operand", () => {
+    const result = bulkUpdateSchema.safeParse({
+      snapshotId: "s1",
+      field: "projected",
+      operation: "add",
+      operand: Infinity,
+      preview: true
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid field", () => {
+    const result = bulkUpdateSchema.safeParse({
+      snapshotId: "s1",
+      field: "variance",
+      operation: "add",
+      operand: 100,
+      preview: true
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("bulkRestoreSchema", () => {
+  it("accepts valid restore payload", () => {
+    const result = bulkRestoreSchema.safeParse({
+      snapshotId: "s1",
+      reason: "Undo bulk change",
+      restores: [{ lineItemId: "li1", period: "2026-01", projectedAmount: "1000.00" }]
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty restores array", () => {
+    const result = bulkRestoreSchema.safeParse({
+      snapshotId: "s1",
+      reason: "Reason",
+      restores: []
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing reason", () => {
+    const result = bulkRestoreSchema.safeParse({
+      snapshotId: "s1",
+      restores: [{ lineItemId: "li1", period: "2026-01" }]
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ── Template schemas ────────────────────────────────────────────────────────
+
+describe("previewTemplateSchema", () => {
+  it("accepts valid preview request", () => {
+    const result = previewTemplateSchema.safeParse({
+      sourceSnapshotId: "s1",
+      targetYear: 2027
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects year below 2000", () => {
+    const result = previewTemplateSchema.safeParse({ sourceSnapshotId: "s1", targetYear: 1999 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects year above 2100", () => {
+    const result = previewTemplateSchema.safeParse({ sourceSnapshotId: "s1", targetYear: 2101 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer year", () => {
+    const result = previewTemplateSchema.safeParse({ sourceSnapshotId: "s1", targetYear: 2026.5 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("onboardTemplateSchema", () => {
+  it("accepts valid onboard request", () => {
+    const result = onboardTemplateSchema.safeParse({
+      sourceSnapshotId: "s1",
+      name: "FY2027",
+      targetYear: 2027,
+      createdBy: "u1"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = onboardTemplateSchema.safeParse({
+      sourceSnapshotId: "s1",
+      name: "   ",
+      targetYear: 2027,
+      createdBy: "u1"
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace manual `isRecord`/`getRequiredString` helpers in all HTTP handlers with Zod schemas
- Add 7 schema files in `lib/validations/` (common, snapshot, group, line-item, value, bulk, template)
- Pin `vite` to `^6` via `overrides` to fix vitest 3.x incompatibility with vite 7 ESM-only build
- 44 new unit tests for every schema in `tests/unit/zod-schemas.test.ts`
- Update 4 handler test assertions to reflect Zod's more-specific error messages (still 400 status)

Closes #30

## Review Findings

Awaiting @codex cross-review.

## Validation

- `npm run test:ci` → 322 tests pass (21 test files)
- `npx tsc --noEmit` → no errors
- `npx prettier --check .` → all files formatted
- `next build` with format-valid Clerk key → passes

## Tests

- Added `tests/unit/zod-schemas.test.ts` (44 tests covering every schema: valid input, required field rejection, format validation, enum rejection, refine conditions)
- Updated `tests/unit/snapshot-http-handlers.test.ts`, `group-http-handlers.test.ts`, `line-item-http-handlers.test.ts`, `value-http-handlers.test.ts` to match Zod error message format

## Risk Check

- **Behaviour neutral**: All API routes still return 400 for invalid input, 422 for threshold errors, 200/201 on success. Zod produces slightly different error message text (more specific), which is a minor UX improvement.
- **No schema migration**: No database changes.
- **vite pin**: `"overrides": { "vite": "^6" }` prevents vite 7 (which requires Node ≥20.19) from breaking tests on Node 20.14. CI uses Node 20 from the workflow; if CI Node is ≥20.19 the override can be removed later.

## Notes for Reviewer

- `lib/validations/group-validation.ts` (manual validators) is preserved — its tests still pass. The new `group-schemas.ts` is used by the handler instead.
- `firstZodError()` in `common.ts` prepends the last path segment when the message alone lacks field context (e.g. `"asOfMonth must be in YYYY-MM format"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)