### PR TITLE
feat: add dev seed script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint-config-prettier": "^10.0.0",
         "prettier": "^3.0.0",
         "prisma": "^6.0.0",
+        "ts-node": "^10.9.2",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0",
         "xlsx": "^0.18.5"
@@ -125,6 +126,18 @@
       },
       "engines": {
         "node": ">=18.17.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1184,12 +1197,31 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -1865,6 +1897,30 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -2635,6 +2691,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/adler-32": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
@@ -2762,6 +2830,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -3467,6 +3541,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3673,6 +3753,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -6047,6 +6136,12 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7819,6 +7914,49 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -8103,6 +8241,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "6.4.1",
@@ -8539,6 +8683,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "test": "vitest",
     "test:ci": "vitest run",
     "prisma:generate": "prisma generate",
-    "prisma:validate": "prisma validate"
+    "prisma:validate": "prisma validate",
+    "db:seed": "prisma db seed"
+  },
+  "prisma": {
+    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.38.3",
@@ -34,6 +38,7 @@
     "eslint-config-prettier": "^10.0.0",
     "prettier": "^3.0.0",
     "prisma": "^6.0.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0",
     "xlsx": "^0.18.5"

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,251 @@
+/**
+ * Seed script for development data.
+ *
+ * Creates a realistic set of groups, line items, one draft snapshot, and
+ * sample projected values for January–June 2026.
+ *
+ * Idempotent: running it twice will not create duplicate records because
+ * all top-level entities are upserted by a stable unique key.
+ */
+
+import { PrismaClient, GroupType, ProjectionMethod, UserRole } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+// ---------------------------------------------------------------------------
+// Seed data definitions
+// ---------------------------------------------------------------------------
+
+const SEED_USERS = [
+  {
+    id: "seed-user-admin",
+    name: "Alice Admin",
+    email: "alice@sukutproperties.com",
+    role: UserRole.admin
+  },
+  {
+    id: "seed-user-editor",
+    name: "Bob Editor",
+    email: "bob@sukutproperties.com",
+    role: UserRole.editor
+  },
+  {
+    id: "seed-user-viewer",
+    name: "Carol Viewer",
+    email: "carol@sukutproperties.com",
+    role: UserRole.viewer
+  }
+];
+
+const SEED_GROUPS = [
+  {
+    id: "seed-group-residential",
+    name: "Residential Properties",
+    groupType: GroupType.sector,
+    sortOrder: 1
+  },
+  {
+    id: "seed-group-commercial",
+    name: "Commercial Properties",
+    groupType: GroupType.sector,
+    sortOrder: 2
+  },
+  {
+    id: "seed-group-nonop",
+    name: "Non-Operating Items",
+    groupType: GroupType.non_operating,
+    sortOrder: 3
+  }
+];
+
+const SEED_LINE_ITEMS = [
+  // Residential
+  {
+    id: "seed-li-res-rent",
+    groupId: "seed-group-residential",
+    label: "Residential Rent Revenue",
+    projectionMethod: ProjectionMethod.annual_spread,
+    projectionParams: { annualTotal: "1200000.00" },
+    sortOrder: 1
+  },
+  {
+    id: "seed-li-res-vacancy",
+    groupId: "seed-group-residential",
+    label: "Vacancy Allowance",
+    projectionMethod: ProjectionMethod.prior_year_pct,
+    projectionParams: { pct: "-0.05" },
+    sortOrder: 2
+  },
+  {
+    id: "seed-li-res-maintenance",
+    groupId: "seed-group-residential",
+    label: "Maintenance & Repairs",
+    projectionMethod: ProjectionMethod.manual,
+    projectionParams: undefined,
+    sortOrder: 3
+  },
+  // Commercial
+  {
+    id: "seed-li-com-rent",
+    groupId: "seed-group-commercial",
+    label: "Commercial Lease Revenue",
+    projectionMethod: ProjectionMethod.annual_spread,
+    projectionParams: { annualTotal: "840000.00" },
+    sortOrder: 1
+  },
+  {
+    id: "seed-li-com-cam",
+    groupId: "seed-group-commercial",
+    label: "CAM Reimbursements",
+    projectionMethod: ProjectionMethod.prior_year_flat,
+    projectionParams: { flatAmount: "5000.00" },
+    sortOrder: 2
+  },
+  // Non-Operating
+  {
+    id: "seed-li-nonop-interest",
+    groupId: "seed-group-nonop",
+    label: "Interest Income",
+    projectionMethod: ProjectionMethod.manual,
+    projectionParams: undefined,
+    sortOrder: 1
+  },
+  {
+    id: "seed-li-nonop-depreciation",
+    groupId: "seed-group-nonop",
+    label: "Depreciation",
+    projectionMethod: ProjectionMethod.annual_spread,
+    projectionParams: { annualTotal: "-360000.00" },
+    sortOrder: 2
+  }
+];
+
+// Monthly projected values for Jan–Jun 2026
+// Format: { lineItemId, period (YYYY-MM-01 as Date), projectedAmount }
+function buildSeedValues(snapshotId: string) {
+  const months = ["2026-01", "2026-02", "2026-03", "2026-04", "2026-05", "2026-06"];
+
+  const amounts: Record<string, string[]> = {
+    "seed-li-res-rent": [
+      "100000.00",
+      "100000.00",
+      "100000.00",
+      "100000.00",
+      "100000.00",
+      "100000.00"
+    ],
+    "seed-li-res-vacancy": ["-5000.00", "-5000.00", "-5000.00", "-5000.00", "-5000.00", "-5000.00"],
+    "seed-li-res-maintenance": ["8000.00", "6000.00", "12000.00", "7000.00", "9000.00", "11000.00"],
+    "seed-li-com-rent": ["70000.00", "70000.00", "70000.00", "70000.00", "70000.00", "70000.00"],
+    "seed-li-com-cam": ["5000.00", "5000.00", "5000.00", "5000.00", "5000.00", "5000.00"],
+    "seed-li-nonop-interest": ["1200.00", "1200.00", "1200.00", "1200.00", "1200.00", "1200.00"],
+    "seed-li-nonop-depreciation": [
+      "-30000.00",
+      "-30000.00",
+      "-30000.00",
+      "-30000.00",
+      "-30000.00",
+      "-30000.00"
+    ]
+  };
+
+  const entries = [];
+  for (const [lineItemId, monthlyAmounts] of Object.entries(amounts)) {
+    for (let i = 0; i < months.length; i++) {
+      entries.push({
+        lineItemId,
+        snapshotId,
+        period: new Date(`${months[i]}-01T00:00:00.000Z`),
+        projectedAmount: monthlyAmounts[i]
+      });
+    }
+  }
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Main seed function
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("🌱 Starting seed...");
+
+  // Users
+  for (const user of SEED_USERS) {
+    await prisma.user.upsert({
+      where: { email: user.email },
+      update: { name: user.name, role: user.role },
+      create: user
+    });
+    console.log(`  ✓ User: ${user.name}`);
+  }
+
+  // Groups
+  for (const group of SEED_GROUPS) {
+    await prisma.group.upsert({
+      where: { id: group.id },
+      update: { name: group.name, groupType: group.groupType, sortOrder: group.sortOrder },
+      create: { ...group, createdBy: "seed-user-admin" }
+    });
+    console.log(`  ✓ Group: ${group.name}`);
+  }
+
+  // Line items
+  for (const item of SEED_LINE_ITEMS) {
+    await prisma.lineItem.upsert({
+      where: { id: item.id },
+      update: {
+        label: item.label,
+        projectionMethod: item.projectionMethod,
+        projectionParams: item.projectionParams,
+        sortOrder: item.sortOrder
+      },
+      create: item
+    });
+    console.log(`  ✓ LineItem: ${item.label}`);
+  }
+
+  // Snapshot (draft, FY2026)
+  const snapshot = await prisma.snapshot.upsert({
+    where: { id: "seed-snapshot-fy2026" },
+    update: { name: "FY2026 Draft" },
+    create: {
+      id: "seed-snapshot-fy2026",
+      name: "FY2026 Draft",
+      asOfMonth: new Date("2026-01-01T00:00:00.000Z"),
+      status: "draft",
+      createdBy: "seed-user-admin"
+    }
+  });
+  console.log(`  ✓ Snapshot: ${snapshot.name}`);
+
+  // Values (upsert each month × line item)
+  const valueEntries = buildSeedValues(snapshot.id);
+  let valueCount = 0;
+  for (const entry of valueEntries) {
+    await prisma.value.upsert({
+      where: {
+        lineItemId_snapshotId_period: {
+          lineItemId: entry.lineItemId,
+          snapshotId: entry.snapshotId,
+          period: entry.period
+        }
+      },
+      update: { projectedAmount: entry.projectedAmount },
+      create: { ...entry, updatedBy: "seed-user-admin" }
+    });
+    valueCount++;
+  }
+  console.log(`  ✓ Values: ${valueCount} entries (7 line items × 6 months)`);
+
+  console.log("✅ Seed complete.");
+}
+
+main()
+  .catch((e) => {
+    console.error("❌ Seed failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary
- Creates `prisma/seed.ts` with realistic dev data: 3 users, 3 groups, 7 line items, 1 draft FY2026 snapshot, 42 projected values (Jan–Jun 2026)
- Script is idempotent — all records upserted by stable IDs, safe to re-run
- Adds `ts-node@^10.9.2` as dev dependency (required by `prisma db seed`)
- Adds `db:seed` script and `prisma.seed` config to `package.json`

Closes #38

## Review Findings
- [ ] No findings yet — awaiting Codex review

## Validation
- [x] `npm run test:ci` — 396 tests pass (seed is pure data, no logic to test)
- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean

## Tests

[no-tests] The seed script contains only declarative data and Prisma upsert calls with no business logic. Correctness is verified by running `npm run db:seed` against a dev database. Unit testing Prisma upsert calls would require a live DB and is outside the scope of the unit/integration test suite.

## Risk Check
- [x] Dev-only: seed data uses fixed IDs prefixed `seed-` to avoid collision with real data
- [x] No schema changes — all models use existing columns
- [x] No impact on test suite or production build
- [x] `ts-node` added only as devDependency, not bundled in production

## Notes for Reviewer
- Fixed IDs (`seed-user-admin`, `seed-group-residential`, etc.) make the seed idempotent and also allow tests in other scripts to reference them as known IDs
- `projectionParams` uses `undefined` (not `null`) because Prisma's JSON field type requires `NullableJsonNullValueInput | InputJsonValue | undefined` — passing `null` causes a TS error

🤖 Generated with [Claude Code](https://claude.com/claude-code)