### PR TITLE
refactor: typed error classes replace string-matched detection

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,54 @@
+/**
+ * Typed error classes for the service layer.
+ *
+ * Services throw these; HTTP handlers check with instanceof instead of
+ * inspecting error.message strings.
+ */
+
+/** Thrown when a requested record does not exist. */
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NotFoundError";
+  }
+}
+
+/** Thrown when attempting to lock an already-locked snapshot. */
+export class AlreadyLockedError extends Error {
+  constructor(message = "Snapshot is already locked") {
+    super(message);
+    this.name = "AlreadyLockedError";
+  }
+}
+
+/** Thrown when attempting to unlock an already-draft (unlocked) snapshot. */
+export class AlreadyUnlockedError extends Error {
+  constructor(message = "Snapshot is already unlocked") {
+    super(message);
+    this.name = "AlreadyUnlockedError";
+  }
+}
+
+/** Thrown when attempting to copy from a snapshot that is not locked. */
+export class SourceNotLockedError extends Error {
+  constructor(message = "Can only copy from a locked snapshot") {
+    super(message);
+    this.name = "SourceNotLockedError";
+  }
+}
+
+/** Thrown when attempting to archive a group or line item that is already inactive. */
+export class AlreadyArchivedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AlreadyArchivedError";
+  }
+}
+
+/** Thrown when a mutation is attempted on a locked snapshot. */
+export class LockedSnapshotError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LockedSnapshotError";
+  }
+}

--- a/lib/groups/group-service.ts
+++ b/lib/groups/group-service.ts
@@ -1,6 +1,7 @@
-import type { PrismaClient } from "@prisma/client";
+import { type PrismaClient, Prisma } from "@prisma/client";
 import { diffFields, type AuditService } from "../audit";
 import type { ArchiveGroupInput, CreateGroupInput, GroupType, UpdateGroupInput } from "./types";
+import { AlreadyArchivedError, NotFoundError } from "@/lib/errors";
 
 const TRACKED_GROUP_FIELDS = ["name", "groupType", "sortOrder", "isActive", "archivedAt"];
 
@@ -22,7 +23,14 @@ export class GroupService {
   }
 
   async getById(groupId: string) {
-    return this.prisma.group.findUniqueOrThrow({ where: { id: groupId } });
+    try {
+      return await this.prisma.group.findUniqueOrThrow({ where: { id: groupId } });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Group not found: ${groupId}`);
+      }
+      throw e;
+    }
   }
 
   async create(input: CreateGroupInput) {
@@ -56,7 +64,15 @@ export class GroupService {
   }
 
   async update(input: UpdateGroupInput) {
-    const current = await this.prisma.group.findUniqueOrThrow({ where: { id: input.groupId } });
+    let current;
+    try {
+      current = await this.prisma.group.findUniqueOrThrow({ where: { id: input.groupId } });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Group not found: ${input.groupId}`);
+      }
+      throw e;
+    }
 
     if (input.groupType !== undefined && !isGroupType(input.groupType)) {
       throw new Error("Invalid groupType");
@@ -85,10 +101,18 @@ export class GroupService {
   }
 
   async archive(input: ArchiveGroupInput) {
-    const current = await this.prisma.group.findUniqueOrThrow({ where: { id: input.groupId } });
+    let current;
+    try {
+      current = await this.prisma.group.findUniqueOrThrow({ where: { id: input.groupId } });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Group not found: ${input.groupId}`);
+      }
+      throw e;
+    }
 
     if (!current.isActive) {
-      throw new Error("Group is already archived");
+      throw new AlreadyArchivedError("Group is already archived");
     }
 
     const updated = await this.prisma.group.update({

--- a/lib/groups/http-handlers.ts
+++ b/lib/groups/http-handlers.ts
@@ -5,6 +5,7 @@ import {
   archiveGroupSchema,
   firstZodError
 } from "@/lib/validations";
+import { AlreadyArchivedError, NotFoundError } from "@/lib/errors";
 
 type HandlerResult = {
   status: number;
@@ -18,16 +19,6 @@ type GroupServiceLike = {
   update: (input: UpdateGroupInput) => Promise<unknown>;
   archive: (input: ArchiveGroupInput) => Promise<unknown>;
 };
-
-function asErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return "Unexpected error";
-}
-
-function isNotFound(error: unknown): boolean {
-  const message = asErrorMessage(error).toLowerCase();
-  return message.includes("not found") || (message.includes("no") && message.includes("found"));
-}
 
 export async function listGroups(
   service: GroupServiceLike,
@@ -50,7 +41,7 @@ export async function getGroup(service: GroupServiceLike, groupId: string): Prom
     const data = await service.getById(groupId);
     return { status: 200, body: { data } };
   } catch (error) {
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Group not found" } };
     }
     return { status: 500, body: { error: "Failed to fetch group" } };
@@ -95,7 +86,7 @@ export async function updateGroup(
     });
     return { status: 200, body: { data } };
   } catch (error) {
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Group not found" } };
     }
     return { status: 500, body: { error: "Failed to update group" } };
@@ -116,12 +107,11 @@ export async function archiveGroup(
     const data = await service.archive({ groupId, archivedBy: archivedBy ?? null, reason });
     return { status: 200, body: { data } };
   } catch (error) {
-    const message = asErrorMessage(error);
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Group not found" } };
     }
-    if (message.includes("already archived")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof AlreadyArchivedError) {
+      return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Failed to archive group" } };
   }

--- a/lib/line-items/http-handlers.ts
+++ b/lib/line-items/http-handlers.ts
@@ -10,6 +10,7 @@ import {
   archiveLineItemSchema,
   firstZodError
 } from "@/lib/validations";
+import { AlreadyArchivedError, NotFoundError } from "@/lib/errors";
 
 type HandlerResult = {
   status: number;
@@ -23,16 +24,6 @@ type LineItemServiceLike = {
   update: (input: UpdateLineItemInput) => Promise<unknown>;
   archive: (input: ArchiveLineItemInput) => Promise<unknown>;
 };
-
-function asErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return "Unexpected error";
-}
-
-function isNotFound(error: unknown): boolean {
-  const message = asErrorMessage(error).toLowerCase();
-  return message.includes("not found") || (message.includes("no") && message.includes("found"));
-}
 
 export async function listLineItems(
   service: LineItemServiceLike,
@@ -59,7 +50,7 @@ export async function getLineItem(
     const data = await service.getById(lineItemId);
     return { status: 200, body: { data } };
   } catch (error) {
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Line item not found" } };
     }
     return { status: 500, body: { error: "Failed to fetch line item" } };
@@ -123,7 +114,7 @@ export async function updateLineItem(
     });
     return { status: 200, body: { data } };
   } catch (error) {
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Line item not found" } };
     }
     return { status: 500, body: { error: "Failed to update line item" } };
@@ -144,12 +135,11 @@ export async function archiveLineItem(
     const data = await service.archive({ lineItemId, archivedBy: archivedBy ?? null, reason });
     return { status: 200, body: { data } };
   } catch (error) {
-    const message = asErrorMessage(error);
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Line item not found" } };
     }
-    if (message.includes("already archived")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof AlreadyArchivedError) {
+      return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Failed to archive line item" } };
   }

--- a/lib/line-items/line-item-service.ts
+++ b/lib/line-items/line-item-service.ts
@@ -1,5 +1,6 @@
-import type { PrismaClient } from "@prisma/client";
+import { type PrismaClient, Prisma } from "@prisma/client";
 import { diffFields, type AuditService } from "../audit";
+import { AlreadyArchivedError, NotFoundError } from "@/lib/errors";
 import type {
   ArchiveLineItemInput,
   CreateLineItemInput,
@@ -51,7 +52,14 @@ export class LineItemService {
   }
 
   async getById(lineItemId: string) {
-    return this.prisma.lineItem.findUniqueOrThrow({ where: { id: lineItemId } });
+    try {
+      return await this.prisma.lineItem.findUniqueOrThrow({ where: { id: lineItemId } });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Line item not found: ${lineItemId}`);
+      }
+      throw e;
+    }
   }
 
   async create(input: CreateLineItemInput) {
@@ -89,9 +97,17 @@ export class LineItemService {
   }
 
   async update(input: UpdateLineItemInput) {
-    const current = await this.prisma.lineItem.findUniqueOrThrow({
-      where: { id: input.lineItemId }
-    });
+    let current;
+    try {
+      current = await this.prisma.lineItem.findUniqueOrThrow({
+        where: { id: input.lineItemId }
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Line item not found: ${input.lineItemId}`);
+      }
+      throw e;
+    }
 
     if (input.projectionMethod !== undefined && !isProjectionMethod(input.projectionMethod)) {
       throw new Error("Invalid projectionMethod");
@@ -126,12 +142,20 @@ export class LineItemService {
   }
 
   async archive(input: ArchiveLineItemInput) {
-    const current = await this.prisma.lineItem.findUniqueOrThrow({
-      where: { id: input.lineItemId }
-    });
+    let current;
+    try {
+      current = await this.prisma.lineItem.findUniqueOrThrow({
+        where: { id: input.lineItemId }
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Line item not found: ${input.lineItemId}`);
+      }
+      throw e;
+    }
 
     if (!current.isActive) {
-      throw new Error("Line item is already archived");
+      throw new AlreadyArchivedError("Line item is already archived");
     }
 
     const updated = await this.prisma.lineItem.update({

--- a/lib/snapshots/compare-service.ts
+++ b/lib/snapshots/compare-service.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js";
-import type { PrismaClient } from "@prisma/client";
+import { type PrismaClient, Prisma } from "@prisma/client";
+import { NotFoundError } from "@/lib/errors";
 
 export interface CompareCellData {
   aProjected: string | null;
@@ -58,6 +59,18 @@ export class CompareService {
   constructor(private prisma: PrismaClient) {}
 
   async compare(snapshotAId: string, snapshotBId: string): Promise<SnapshotCompareResult> {
+    try {
+      await Promise.all([
+        this.prisma.snapshot.findUniqueOrThrow({ where: { id: snapshotAId } }),
+        this.prisma.snapshot.findUniqueOrThrow({ where: { id: snapshotBId } })
+      ]);
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError("One or both snapshots not found");
+      }
+      throw e;
+    }
+
     const [snapA, snapB, valuesA, valuesB, groups] = await Promise.all([
       this.prisma.snapshot.findUniqueOrThrow({ where: { id: snapshotAId } }),
       this.prisma.snapshot.findUniqueOrThrow({ where: { id: snapshotBId } }),

--- a/lib/snapshots/http-handlers.ts
+++ b/lib/snapshots/http-handlers.ts
@@ -13,6 +13,12 @@ import {
   compareSnapshotParamsSchema,
   firstZodError
 } from "@/lib/validations";
+import {
+  AlreadyLockedError,
+  AlreadyUnlockedError,
+  NotFoundError,
+  SourceNotLockedError
+} from "@/lib/errors";
 
 type HandlerResult = {
   status: number;
@@ -31,16 +37,6 @@ type SnapshotServiceLike = {
 type CompareServiceLike = {
   compare: (snapshotAId: string, snapshotBId: string) => Promise<SnapshotCompareResult>;
 };
-
-function asErrorMessage(error: unknown): string {
-  if (error instanceof Error && error.message) return error.message;
-  return "Unexpected error";
-}
-
-function isNotFound(error: unknown): boolean {
-  const message = asErrorMessage(error).toLowerCase();
-  return message.includes("not found") || (message.includes("no") && message.includes("found"));
-}
 
 export async function listSnapshots(service: SnapshotServiceLike): Promise<HandlerResult> {
   try {
@@ -63,7 +59,7 @@ export async function getSnapshot(
     const data = await service.getById(snapshotId);
     return { status: 200, body: { data } };
   } catch (error) {
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Snapshot not found" } };
     }
     return { status: 500, body: { error: "Failed to fetch snapshot" } };
@@ -101,9 +97,8 @@ export async function lockSnapshot(
     const data = await service.lock({ snapshotId, lockedBy, reason });
     return { status: 200, body: { data } };
   } catch (error) {
-    const message = asErrorMessage(error);
-    if (message.includes("already locked")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof AlreadyLockedError) {
+      return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Failed to lock snapshot" } };
   }
@@ -123,9 +118,8 @@ export async function unlockSnapshot(
     const data = await service.unlock({ snapshotId, unlockedBy, reason });
     return { status: 200, body: { data } };
   } catch (error) {
-    const message = asErrorMessage(error);
-    if (message.includes("already unlocked")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof AlreadyUnlockedError) {
+      return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Failed to unlock snapshot" } };
   }
@@ -144,9 +138,8 @@ export async function copySnapshot(
     const data = await service.copyFromPrior(result.data);
     return { status: 201, body: { data } };
   } catch (error) {
-    const message = asErrorMessage(error);
-    if (message.includes("Can only copy from a locked snapshot")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof SourceNotLockedError) {
+      return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Failed to copy snapshot" } };
   }
@@ -169,7 +162,7 @@ export async function compareSnapshots(
     const data = await service.compare(result.data.a, result.data.b);
     return { status: 200, body: { data } };
   } catch (error) {
-    if (isNotFound(error)) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "One or both snapshots not found" } };
     }
     return { status: 500, body: { error: "Failed to compare snapshots" } };

--- a/lib/snapshots/snapshot-service.ts
+++ b/lib/snapshots/snapshot-service.ts
@@ -1,4 +1,10 @@
-import type { PrismaClient } from "@prisma/client";
+import { type PrismaClient, Prisma } from "@prisma/client";
+import {
+  AlreadyLockedError,
+  AlreadyUnlockedError,
+  NotFoundError,
+  SourceNotLockedError
+} from "@/lib/errors";
 
 type TxClient = Omit<
   PrismaClient,
@@ -65,7 +71,7 @@ export class SnapshotService {
     });
 
     if (snapshot.status === "locked") {
-      throw new Error("Snapshot is already locked");
+      throw new AlreadyLockedError();
     }
 
     // Create structure version and update snapshot in a transaction.
@@ -112,7 +118,7 @@ export class SnapshotService {
     });
 
     if (snapshot.status === "draft") {
-      throw new Error("Snapshot is already unlocked");
+      throw new AlreadyUnlockedError();
     }
 
     // Include status: "locked" in WHERE so a concurrent re-lock between the
@@ -149,7 +155,7 @@ export class SnapshotService {
     });
 
     if (source.status !== "locked") {
-      throw new Error("Can only copy from a locked snapshot");
+      throw new SourceNotLockedError();
     }
 
     const sourceValues = await this.prisma.value.findMany({
@@ -216,13 +222,20 @@ export class SnapshotService {
    * Get a single snapshot by ID with related data.
    */
   async getById(snapshotId: string) {
-    return this.prisma.snapshot.findUniqueOrThrow({
-      where: { id: snapshotId },
-      include: {
-        creator: { select: { id: true, name: true, email: true } },
-        locker: { select: { id: true, name: true, email: true } },
-        structureVersion: true
+    try {
+      return await this.prisma.snapshot.findUniqueOrThrow({
+        where: { id: snapshotId },
+        include: {
+          creator: { select: { id: true, name: true, email: true } },
+          locker: { select: { id: true, name: true, email: true } },
+          structureVersion: true
+        }
+      });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new NotFoundError(`Snapshot not found: ${snapshotId}`);
       }
-    });
+      throw e;
+    }
   }
 }

--- a/lib/values/bulk-http-handlers.ts
+++ b/lib/values/bulk-http-handlers.ts
@@ -1,5 +1,6 @@
 import type { BulkField, BulkOperation } from "./bulk-service";
 import { bulkUpdateSchema, bulkRestoreSchema, firstZodError } from "@/lib/validations";
+import { LockedSnapshotError } from "@/lib/errors";
 
 type HandlerResult = {
   status: number;
@@ -65,10 +66,7 @@ export async function handleBulkUpdate(
     );
     return { status: 200, body: { data } };
   } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message === "Cannot apply bulk updates to a locked snapshot"
-    ) {
+    if (error instanceof LockedSnapshotError) {
       return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Bulk update failed" } };
@@ -96,7 +94,7 @@ export async function handleBulkRestore(
     const data = await service.restore(snapshotId, normalizedRestores, reason, updatedBy ?? null);
     return { status: 200, body: { data } };
   } catch (error) {
-    if (error instanceof Error && error.message === "Cannot restore values in a locked snapshot") {
+    if (error instanceof LockedSnapshotError) {
       return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Bulk restore failed" } };

--- a/lib/values/bulk-service.ts
+++ b/lib/values/bulk-service.ts
@@ -1,5 +1,6 @@
 import Decimal from "decimal.js";
 import type { PrismaClient } from "@prisma/client";
+import { LockedSnapshotError } from "@/lib/errors";
 
 type TxClient = Omit<
   PrismaClient,
@@ -80,7 +81,7 @@ export class BulkValueService {
       select: { status: true }
     });
     if (snap.status === "locked") {
-      throw new Error("Cannot apply bulk updates to a locked snapshot");
+      throw new LockedSnapshotError("Cannot apply bulk updates to a locked snapshot");
     }
 
     const values = await this.fetchValues(snapshotId, groupId);
@@ -142,7 +143,7 @@ export class BulkValueService {
       select: { status: true }
     });
     if (snap.status === "locked") {
-      throw new Error("Cannot restore values in a locked snapshot");
+      throw new LockedSnapshotError("Cannot restore values in a locked snapshot");
     }
 
     await this.prisma.$transaction(async (tx: TxClient) => {

--- a/lib/values/http-handlers.ts
+++ b/lib/values/http-handlers.ts
@@ -1,6 +1,7 @@
 import type { ListValuesInput, UpsertValueInput } from "./types";
 import { MaterialChangeRequiredError } from "./threshold";
 import { upsertValueSchema, firstZodError } from "@/lib/validations";
+import { LockedSnapshotError } from "@/lib/errors";
 
 type HandlerResult = {
   status: number;
@@ -64,7 +65,7 @@ export async function upsertValue(
         }
       };
     }
-    if (error instanceof Error && error.message === "Cannot edit values in a locked snapshot") {
+    if (error instanceof LockedSnapshotError) {
       return { status: 409, body: { error: error.message } };
     }
     return { status: 500, body: { error: "Failed to upsert value" } };

--- a/lib/values/value-service.ts
+++ b/lib/values/value-service.ts
@@ -3,6 +3,7 @@ import type { PrismaClient } from "@prisma/client";
 import { diffFields, type AuditService } from "../audit";
 import type { ListValuesInput, UpsertValueInput } from "./types";
 import { checkMaterialChange, MaterialChangeRequiredError } from "./threshold";
+import { LockedSnapshotError } from "@/lib/errors";
 
 function parsePeriod(period: string): Date {
   const match = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(period);
@@ -46,7 +47,7 @@ export class ValueService {
       select: { status: true }
     });
     if (snapshot.status === "locked") {
-      throw new Error("Cannot edit values in a locked snapshot");
+      throw new LockedSnapshotError("Cannot edit values in a locked snapshot");
     }
 
     const periodDate = parsePeriod(input.period);

--- a/tests/integration/line-items-api.test.ts
+++ b/tests/integration/line-items-api.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
+import { AlreadyArchivedError, NotFoundError } from "@/lib/errors";
 
 vi.mock("@/lib/auth", () => ({
   requireSignedIn: vi.fn(),
@@ -200,7 +201,7 @@ describe("GET /api/line-items/[lineItemId]", () => {
 
   it("returns 404 when line item not found", async () => {
     (lineItemService.getById as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("No LineItem found")
+      new NotFoundError("Line item not found: missing")
     );
     const req = makeRequest("GET", "http://localhost/api/line-items/missing");
     const res = await getLineItemRoute(req, makeParams("missing"));
@@ -276,7 +277,7 @@ describe("DELETE /api/line-items/[lineItemId]", () => {
 
   it("returns 409 when already archived", async () => {
     (lineItemService.archive as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Line item is already archived")
+      new AlreadyArchivedError("Line item is already archived")
     );
     const req = makeRequest("DELETE", "http://localhost/api/line-items/li-1", {
       archivedBy: "admin-1"

--- a/tests/integration/snapshots-api.test.ts
+++ b/tests/integration/snapshots-api.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
+import { AlreadyLockedError, AlreadyUnlockedError, SourceNotLockedError } from "@/lib/errors";
 
 vi.mock("@/lib/auth", () => ({
   requireSignedIn: vi.fn(),
@@ -171,9 +172,7 @@ describe("POST /api/snapshots/lock", () => {
   });
 
   it("returns 409 when snapshot already locked", async () => {
-    (snapshotService.lock as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Snapshot is already locked")
-    );
+    (snapshotService.lock as ReturnType<typeof vi.fn>).mockRejectedValue(new AlreadyLockedError());
     const req = makeRequest("POST", { snapshotId: "s1", lockedBy: "admin-1" });
     const res = await lockSnapshotRoute(req);
     expect(res.status).toBe(409);
@@ -206,7 +205,7 @@ describe("POST /api/snapshots/unlock", () => {
 
   it("returns 409 when snapshot already draft", async () => {
     (snapshotService.unlock as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Snapshot is already unlocked")
+      new AlreadyUnlockedError()
     );
     const req = makeRequest("POST", { snapshotId: "s1", unlockedBy: "admin-1" });
     const res = await unlockSnapshotRoute(req);
@@ -246,7 +245,7 @@ describe("POST /api/snapshots/copy", () => {
 
   it("returns 409 when source is not locked", async () => {
     (snapshotService.copyFromPrior as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Can only copy from a locked snapshot")
+      new SourceNotLockedError()
     );
     const req = makeRequest("POST", {
       sourceSnapshotId: "s1",

--- a/tests/integration/values-api.test.ts
+++ b/tests/integration/values-api.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
 import { MaterialChangeRequiredError } from "@/lib/values/threshold";
+import { LockedSnapshotError } from "@/lib/errors";
 
 vi.mock("@/lib/auth", () => ({
   requireSignedIn: vi.fn(),
@@ -123,7 +124,7 @@ describe("POST /api/values/upsert", () => {
 
   it("returns 409 when snapshot is locked", async () => {
     (valueService.upsert as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Cannot edit values in a locked snapshot")
+      new LockedSnapshotError("Cannot edit values in a locked snapshot")
     );
     const req = makeRequest("http://localhost/api/values/upsert", {
       lineItemId: "li-1",
@@ -260,7 +261,7 @@ describe("POST /api/values/bulk-update", () => {
 
   it("returns 409 when snapshot is locked", async () => {
     (bulkValueService.apply as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Cannot apply bulk updates to a locked snapshot")
+      new LockedSnapshotError("Cannot apply bulk updates to a locked snapshot")
     );
     const req = makeRequest("http://localhost/api/values/bulk-update", {
       snapshotId: "snap-locked",
@@ -352,7 +353,7 @@ describe("POST /api/values/bulk-restore", () => {
 
   it("returns 409 when snapshot is locked", async () => {
     (bulkValueService.restore as ReturnType<typeof vi.fn>).mockRejectedValue(
-      new Error("Cannot restore values in a locked snapshot")
+      new LockedSnapshotError("Cannot restore values in a locked snapshot")
     );
     const req = makeRequest("http://localhost/api/values/bulk-restore", {
       snapshotId: "snap-locked",

--- a/tests/unit/bulk-http-handlers.test.ts
+++ b/tests/unit/bulk-http-handlers.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleBulkUpdate, handleBulkRestore } from "../../lib/values/bulk-http-handlers";
+import { LockedSnapshotError } from "../../lib/errors";
 
 function createMockService() {
   return {
@@ -69,7 +70,7 @@ describe("handleBulkUpdate", () => {
 
   it("returns 409 when snapshot is locked", async () => {
     mockService.apply.mockRejectedValueOnce(
-      new Error("Cannot apply bulk updates to a locked snapshot")
+      new LockedSnapshotError("Cannot apply bulk updates to a locked snapshot")
     );
 
     const result = await handleBulkUpdate(mockService, {
@@ -138,7 +139,7 @@ describe("handleBulkRestore", () => {
 
   it("returns 409 when snapshot is locked", async () => {
     mockService.restore.mockRejectedValueOnce(
-      new Error("Cannot restore values in a locked snapshot")
+      new LockedSnapshotError("Cannot restore values in a locked snapshot")
     );
 
     const result = await handleBulkRestore(mockService, {

--- a/tests/unit/group-http-handlers.test.ts
+++ b/tests/unit/group-http-handlers.test.ts
@@ -6,6 +6,7 @@ import {
   listGroups,
   updateGroup
 } from "../../lib/groups/http-handlers";
+import { AlreadyArchivedError, NotFoundError } from "../../lib/errors";
 
 function createMockService() {
   return {
@@ -41,7 +42,7 @@ describe("group HTTP handlers", () => {
   });
 
   it("returns 404 when group is not found", async () => {
-    mockService.getById.mockRejectedValueOnce(new Error("No Group found"));
+    mockService.getById.mockRejectedValueOnce(new NotFoundError("Group not found: missing"));
 
     const result = await getGroup(mockService, "missing");
 
@@ -119,7 +120,9 @@ describe("group HTTP handlers", () => {
   });
 
   it("returns 409 when group is already archived", async () => {
-    mockService.archive.mockRejectedValueOnce(new Error("Group is already archived"));
+    mockService.archive.mockRejectedValueOnce(
+      new AlreadyArchivedError("Group is already archived")
+    );
 
     const result = await archiveGroup(mockService, {
       groupId: "grp-1",

--- a/tests/unit/line-item-http-handlers.test.ts
+++ b/tests/unit/line-item-http-handlers.test.ts
@@ -6,6 +6,7 @@ import {
   listLineItems,
   updateLineItem
 } from "../../lib/line-items/http-handlers";
+import { AlreadyArchivedError, NotFoundError } from "../../lib/errors";
 
 function createMockService() {
   return {
@@ -41,7 +42,7 @@ describe("line item HTTP handlers", () => {
   });
 
   it("returns 404 when line item is not found", async () => {
-    mockService.getById.mockRejectedValueOnce(new Error("No LineItem found"));
+    mockService.getById.mockRejectedValueOnce(new NotFoundError("Line item not found: missing"));
 
     const result = await getLineItem(mockService, "missing");
 
@@ -122,7 +123,9 @@ describe("line item HTTP handlers", () => {
   });
 
   it("returns 409 when line item is already archived", async () => {
-    mockService.archive.mockRejectedValueOnce(new Error("Line item is already archived"));
+    mockService.archive.mockRejectedValueOnce(
+      new AlreadyArchivedError("Line item is already archived")
+    );
 
     const result = await archiveLineItem(mockService, {
       lineItemId: "li-1",

--- a/tests/unit/snapshot-http-handlers.test.ts
+++ b/tests/unit/snapshot-http-handlers.test.ts
@@ -7,6 +7,12 @@ import {
   lockSnapshot,
   unlockSnapshot
 } from "../../lib/snapshots/http-handlers";
+import {
+  AlreadyLockedError,
+  AlreadyUnlockedError,
+  NotFoundError,
+  SourceNotLockedError
+} from "../../lib/errors";
 
 function createMockService() {
   return {
@@ -43,7 +49,7 @@ describe("snapshot HTTP handlers", () => {
   });
 
   it("returns 404 when snapshot is not found", async () => {
-    mockService.getById.mockRejectedValueOnce(new Error("No Snapshot found"));
+    mockService.getById.mockRejectedValueOnce(new NotFoundError("Snapshot not found: missing"));
 
     const result = await getSnapshot(mockService, "missing");
 
@@ -93,7 +99,7 @@ describe("snapshot HTTP handlers", () => {
   });
 
   it("returns 409 if snapshot is already locked", async () => {
-    mockService.lock.mockRejectedValueOnce(new Error("Snapshot is already locked"));
+    mockService.lock.mockRejectedValueOnce(new AlreadyLockedError());
 
     const result = await lockSnapshot(mockService, {
       snapshotId: "snap-1",
@@ -120,7 +126,7 @@ describe("snapshot HTTP handlers", () => {
   });
 
   it("returns 409 if snapshot is already unlocked", async () => {
-    mockService.unlock.mockRejectedValueOnce(new Error("Snapshot is already unlocked"));
+    mockService.unlock.mockRejectedValueOnce(new AlreadyUnlockedError());
 
     const result = await unlockSnapshot(mockService, {
       snapshotId: "snap-1",
@@ -146,9 +152,7 @@ describe("snapshot HTTP handlers", () => {
   });
 
   it("returns 409 if copy source snapshot is not locked", async () => {
-    mockService.copyFromPrior.mockRejectedValueOnce(
-      new Error("Can only copy from a locked snapshot")
-    );
+    mockService.copyFromPrior.mockRejectedValueOnce(new SourceNotLockedError());
 
     const result = await copySnapshot(mockService, {
       sourceSnapshotId: "snap-draft",

--- a/tests/unit/value-http-handlers.test.ts
+++ b/tests/unit/value-http-handlers.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { listValues, upsertValue } from "../../lib/values/http-handlers";
 import { MaterialChangeRequiredError } from "../../lib/values/threshold";
+import { LockedSnapshotError } from "../../lib/errors";
 
 function createMockService() {
   return {
@@ -110,7 +111,9 @@ describe("value HTTP handlers", () => {
   });
 
   it("returns 409 when snapshot is locked", async () => {
-    mockService.upsert.mockRejectedValueOnce(new Error("Cannot edit values in a locked snapshot"));
+    mockService.upsert.mockRejectedValueOnce(
+      new LockedSnapshotError("Cannot edit values in a locked snapshot")
+    );
 
     const result = await upsertValue(mockService, {
       lineItemId: "li-1",


### PR DESCRIPTION
## Summary

- Adds `lib/errors.ts` with six typed error classes: `NotFoundError`, `AlreadyLockedError`, `AlreadyUnlockedError`, `SourceNotLockedError`, `AlreadyArchivedError`, `LockedSnapshotError`
- All services throw typed errors instead of plain `Error`
- Prisma P2025 (record not found) is caught at the service boundary and rethrown as `NotFoundError`
- All HTTP handlers use `instanceof` checks instead of fragile `message.includes(...)` string matching
- Removed `asErrorMessage` and `isNotFound` helper functions from all handlers

## Review Findings

- Reviewed all handler catch blocks — every previously string-matched error condition now has a corresponding typed check
- Prisma P2025 wrapping is applied to all `findUniqueOrThrow` calls where the handler returns 404
- `compare-service.ts` does a pre-flight P2025 check before the main query since `Promise.all` makes it hard to identify which snapshot was missing

## Validation

- `npx vitest run` → 420/420 tests pass
- `npx tsc --noEmit` → no type errors
- `npx prettier --check` → all files formatted

## Tests

All existing unit and integration tests updated to throw typed error instances instead of generic `new Error(...)` strings, confirming that `instanceof` checks work end-to-end.

## Risk Check

- No DB schema changes
- No API contract changes — HTTP status codes and error message strings are preserved
- Purely internal refactor; behaviour is identical from the caller's perspective

## Notes for Reviewer

This closes issue #40. The `data-grid.test.ts` and `audit-service.test.ts` tests are unchanged — those services do not expose typed business errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)