### PR TITLE
fix: precision loss, archived group leak, sequential bulk upserts

### DIFF
--- a/lib/exports/excel-export.ts
+++ b/lib/exports/excel-export.ts
@@ -3,6 +3,11 @@ import Decimal from "decimal.js";
 import type { ExportGroup, ExportSnapshotData } from "./types";
 import { formatPeriodLong } from "./types";
 
+/** Convert Decimal to JS number safely — rounds to 2dp first to avoid float drift. */
+function toSafeNumber(d: Decimal): number {
+  return Number(d.toFixed(2));
+}
+
 /**
  * Number format matching the original workbook:
  * - Thousands separator
@@ -139,9 +144,9 @@ export async function generateExcelExport(data: ExportSnapshotData): Promise<any
     }
     netOpValues.push(periodNet.toFixed(2));
     netOpTotal = netOpTotal.plus(periodNet);
-    netOpRow.push(periodNet.toNumber() as never);
+    netOpRow.push(toSafeNumber(periodNet) as never);
   }
-  netOpRow.push(netOpTotal.toNumber() as never);
+  netOpRow.push(toSafeNumber(netOpTotal) as never);
 
   const netOpExcelRow = ws.addRow(netOpRow);
   netOpExcelRow.font = { bold: true, size: 12, name: "Calibri" };
@@ -178,9 +183,9 @@ export async function generateExcelExport(data: ExportSnapshotData): Promise<any
         periodNet = periodNet.plus(groupTotals[i]);
       }
       totalNonOp = totalNonOp.plus(periodNet);
-      totalNonOpRow.push(periodNet.toNumber() as never);
+      totalNonOpRow.push(toSafeNumber(periodNet) as never);
     }
-    totalNonOpRow.push(totalNonOp.toNumber() as never);
+    totalNonOpRow.push(toSafeNumber(totalNonOp) as never);
 
     const totalNonOpExcelRow = ws.addRow(totalNonOpRow);
     totalNonOpExcelRow.font = subtotalFont;
@@ -207,9 +212,9 @@ export async function generateExcelExport(data: ExportSnapshotData): Promise<any
       }
       const net = opTotal.plus(nonOpTotal);
       netCashTotal = netCashTotal.plus(net);
-      netCashRow.push(net.toNumber() as never);
+      netCashRow.push(toSafeNumber(net) as never);
     }
-    netCashRow.push(netCashTotal.toNumber() as never);
+    netCashRow.push(toSafeNumber(netCashTotal) as never);
 
     const netCashExcelRow = ws.addRow(netCashRow);
     netCashExcelRow.font = { bold: true, size: 12, name: "Calibri" };
@@ -262,7 +267,7 @@ function writeGroupSection(
         const dec = new Decimal(amount);
         periodTotals[i] = periodTotals[i].plus(dec);
         grandTotal = grandTotal.plus(dec);
-        row.push(dec.toNumber());
+        row.push(toSafeNumber(dec));
       } else {
         row.push(null);
       }
@@ -277,7 +282,7 @@ function writeGroupSection(
         lineTotal = lineTotal.plus(new Decimal(amount));
       }
     }
-    row.push(lineTotal.toNumber());
+    row.push(toSafeNumber(lineTotal));
 
     const dataRow = ws.addRow(row);
     dataRow.font = styles.dataFont;
@@ -292,9 +297,9 @@ function writeGroupSection(
   const subtotalLabel = `Total ${group.name}`;
   const subtotalRow: (string | number)[] = ["", subtotalLabel];
   for (const t of periodTotals) {
-    subtotalRow.push(t.toNumber());
+    subtotalRow.push(toSafeNumber(t));
   }
-  subtotalRow.push(grandTotal.toNumber());
+  subtotalRow.push(toSafeNumber(grandTotal));
 
   const subtotalExcelRow = ws.addRow(subtotalRow);
   subtotalExcelRow.font = styles.subtotalFont;

--- a/lib/snapshots/compare-service.ts
+++ b/lib/snapshots/compare-service.ts
@@ -102,7 +102,7 @@ export class CompareService {
           }
         }
       }),
-      this.prisma.group.findMany({ orderBy: { sortOrder: "asc" } })
+      this.prisma.group.findMany({ where: { isActive: true }, orderBy: { sortOrder: "asc" } })
     ]);
 
     // Collect periods from both snapshots

--- a/lib/values/bulk-service.ts
+++ b/lib/values/bulk-service.ts
@@ -91,33 +91,39 @@ export class BulkValueService {
     const writes = changes.filter((c) => c.newValue !== null && c.newValue !== c.oldValue);
 
     await this.prisma.$transaction(async (tx: TxClient) => {
-      for (const change of writes) {
-        const periodDate = new Date(`${change.period}-01T00:00:00.000Z`);
-        const update: Record<string, unknown> = { updatedBy };
-        if (field === "projected") {
-          update.projectedAmount = change.newValue;
-        } else {
-          update.actualAmount = change.newValue;
-        }
-
-        await tx.value.upsert({
-          where: {
-            lineItemId_snapshotId_period: {
-              lineItemId: change.lineItemId,
-              snapshotId,
-              period: periodDate
+      const CHUNK_SIZE = 50;
+      for (let i = 0; i < writes.length; i += CHUNK_SIZE) {
+        const chunk = writes.slice(i, i + CHUNK_SIZE);
+        await Promise.all(
+          chunk.map((change) => {
+            const periodDate = new Date(`${change.period}-01T00:00:00.000Z`);
+            const update: Record<string, unknown> = { updatedBy };
+            if (field === "projected") {
+              update.projectedAmount = change.newValue;
+            } else {
+              update.actualAmount = change.newValue;
             }
-          },
-          create: {
-            lineItemId: change.lineItemId,
-            snapshotId,
-            period: periodDate,
-            projectedAmount: field === "projected" ? change.newValue : null,
-            actualAmount: field === "actual" ? change.newValue : null,
-            updatedBy
-          },
-          update
-        });
+
+            return tx.value.upsert({
+              where: {
+                lineItemId_snapshotId_period: {
+                  lineItemId: change.lineItemId,
+                  snapshotId,
+                  period: periodDate
+                }
+              },
+              create: {
+                lineItemId: change.lineItemId,
+                snapshotId,
+                period: periodDate,
+                projectedAmount: field === "projected" ? change.newValue : null,
+                actualAmount: field === "actual" ? change.newValue : null,
+                updatedBy
+              },
+              update
+            });
+          })
+        );
       }
     });
 
@@ -147,30 +153,36 @@ export class BulkValueService {
     }
 
     await this.prisma.$transaction(async (tx: TxClient) => {
-      for (const r of restores) {
-        const periodDate = new Date(`${r.period}-01T00:00:00.000Z`);
-        await tx.value.upsert({
-          where: {
-            lineItemId_snapshotId_period: {
-              lineItemId: r.lineItemId,
-              snapshotId,
-              period: periodDate
-            }
-          },
-          create: {
-            lineItemId: r.lineItemId,
-            snapshotId,
-            period: periodDate,
-            projectedAmount: r.projectedAmount,
-            actualAmount: r.actualAmount,
-            updatedBy
-          },
-          update: {
-            projectedAmount: r.projectedAmount,
-            actualAmount: r.actualAmount,
-            updatedBy
-          }
-        });
+      const CHUNK_SIZE = 50;
+      for (let i = 0; i < restores.length; i += CHUNK_SIZE) {
+        const chunk = restores.slice(i, i + CHUNK_SIZE);
+        await Promise.all(
+          chunk.map((r) => {
+            const periodDate = new Date(`${r.period}-01T00:00:00.000Z`);
+            return tx.value.upsert({
+              where: {
+                lineItemId_snapshotId_period: {
+                  lineItemId: r.lineItemId,
+                  snapshotId,
+                  period: periodDate
+                }
+              },
+              create: {
+                lineItemId: r.lineItemId,
+                snapshotId,
+                period: periodDate,
+                projectedAmount: r.projectedAmount,
+                actualAmount: r.actualAmount,
+                updatedBy
+              },
+              update: {
+                projectedAmount: r.projectedAmount,
+                actualAmount: r.actualAmount,
+                updatedBy
+              }
+            });
+          })
+        );
       }
     });
 


### PR DESCRIPTION
## Summary
- **#52** — Replace `Decimal.toNumber()` with `Number(dec.toFixed(2))` in excel-export to prevent floating-point precision drift on large financial amounts
- **#54** — Add `isActive: true` filter to compare-service group query so archived groups no longer leak into snapshot diffs
- **#56** — Chunk bulk-service upserts into parallel batches of 50 within the transaction, targeting <400ms SLO (ADR-006)

## Test plan
- [x] All 427 existing tests pass
- [ ] Verify Excel export values match expected precision for amounts >2^53
- [ ] Confirm archived groups excluded from `/api/snapshots/compare` response
- [ ] Load test bulk apply with 600 cells and verify <400ms response

Closes #52, #54, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)