### PR TITLE
fix: exclude archived items from template copy + typed errors

### DIFF
--- a/lib/templates/http-handlers.ts
+++ b/lib/templates/http-handlers.ts
@@ -1,5 +1,6 @@
 import type { TemplateService } from "./template-service";
 import { previewTemplateSchema, onboardTemplateSchema, firstZodError } from "@/lib/validations";
+import { NotFoundError, SourceNotLockedError } from "@/lib/errors";
 
 interface HandlerResult {
   status: number;
@@ -24,16 +25,12 @@ export async function previewTemplate(
     const preview = await service.preview(sourceSnapshotId, targetYear);
     return { status: 200, body: preview };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-
-    if (message.includes("not found") || message.includes("No Snapshot found")) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Source snapshot not found" } };
     }
-
-    if (message.includes("Can only onboard from a locked snapshot")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof SourceNotLockedError) {
+      return { status: 409, body: { error: error.message } };
     }
-
     return { status: 500, body: { error: "Failed to generate preview" } };
   }
 }
@@ -56,16 +53,12 @@ export async function onboardTemplate(
     const snapshot = await service.onboard({ sourceSnapshotId, name, targetYear, createdBy });
     return { status: 201, body: snapshot };
   } catch (error) {
-    const message = error instanceof Error ? error.message : "Unknown error";
-
-    if (message.includes("not found") || message.includes("No Snapshot found")) {
+    if (error instanceof NotFoundError) {
       return { status: 404, body: { error: "Source snapshot not found" } };
     }
-
-    if (message.includes("Can only onboard from a locked snapshot")) {
-      return { status: 409, body: { error: message } };
+    if (error instanceof SourceNotLockedError) {
+      return { status: 409, body: { error: error.message } };
     }
-
     return { status: 500, body: { error: "Failed to create snapshot from template" } };
   }
 }

--- a/lib/templates/template-service.ts
+++ b/lib/templates/template-service.ts
@@ -7,6 +7,7 @@ type TxClient = Omit<
 >;
 
 import type { AuditService } from "../audit";
+import { isPrismaNotFound, NotFoundError, SourceNotLockedError } from "@/lib/errors";
 import { calculateProjections } from "../calculations";
 import type { PeriodValue, ProjectionMethod } from "../calculations";
 import type {
@@ -35,12 +36,20 @@ export class TemplateService {
    * Returns the structure that would be copied so admin can review before confirming.
    */
   async preview(sourceSnapshotId: string, targetYear: number): Promise<TemplatePreview> {
-    const source = await this.prisma.snapshot.findUniqueOrThrow({
-      where: { id: sourceSnapshotId }
-    });
+    let source;
+    try {
+      source = await this.prisma.snapshot.findUniqueOrThrow({
+        where: { id: sourceSnapshotId }
+      });
+    } catch (e) {
+      if (isPrismaNotFound(e)) {
+        throw new NotFoundError(`Snapshot not found: ${sourceSnapshotId}`);
+      }
+      throw e;
+    }
 
     if (source.status !== "locked") {
-      throw new Error("Can only onboard from a locked snapshot");
+      throw new SourceNotLockedError();
     }
 
     const groups = await this.prisma.group.findMany({
@@ -54,9 +63,9 @@ export class TemplateService {
       }
     });
 
-    // Fetch all values from the source snapshot for prior-year totals
+    // Fetch values from the source snapshot for prior-year totals (active items only)
     const sourceValues = await this.prisma.value.findMany({
-      where: { snapshotId: sourceSnapshotId }
+      where: { snapshotId: sourceSnapshotId, lineItem: { isActive: true } }
     });
 
     // Build a map: lineItemId -> sum of actual amounts
@@ -125,12 +134,20 @@ export class TemplateService {
    * 4. Audit log the creation
    */
   async onboard(input: OnboardFromTemplateInput) {
-    const source = await this.prisma.snapshot.findUniqueOrThrow({
-      where: { id: input.sourceSnapshotId }
-    });
+    let source;
+    try {
+      source = await this.prisma.snapshot.findUniqueOrThrow({
+        where: { id: input.sourceSnapshotId }
+      });
+    } catch (e) {
+      if (isPrismaNotFound(e)) {
+        throw new NotFoundError(`Snapshot not found: ${input.sourceSnapshotId}`);
+      }
+      throw e;
+    }
 
     if (source.status !== "locked") {
-      throw new Error("Can only onboard from a locked snapshot");
+      throw new SourceNotLockedError();
     }
 
     const targetPeriods = generateFiscalYearPeriods(input.targetYear);
@@ -147,9 +164,9 @@ export class TemplateService {
       }
     });
 
-    // Fetch source snapshot values for prior-year-based methods
+    // Fetch source snapshot values for prior-year-based methods (active items only)
     const sourceValues = await this.prisma.value.findMany({
-      where: { snapshotId: source.id }
+      where: { snapshotId: source.id, lineItem: { isActive: true } }
     });
 
     // Build prior year values map: lineItemId -> PeriodValue[]

--- a/tests/unit/template-service.test.ts
+++ b/tests/unit/template-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { TemplateService } from "../../lib/templates";
 import { generateFiscalYearPeriods } from "../../lib/templates/types";
+import { NotFoundError, SourceNotLockedError } from "../../lib/errors";
 
 // ---------------------------------------------------------------------------
 // generateFiscalYearPeriods — pure function tests
@@ -236,11 +237,27 @@ describe("TemplateService.preview", () => {
     expect(preview.groups[1].lineItems[0].projectionMethod).toBe("prior_year_pct");
   });
 
-  it("throws if source snapshot is not locked", async () => {
+  it("throws SourceNotLockedError if source snapshot is not locked", async () => {
     prisma.snapshot.findUniqueOrThrow.mockResolvedValue(MOCK_DRAFT_SNAPSHOT);
 
-    await expect(service.preview("snap-2026-draft", 2027)).rejects.toThrow(
-      "Can only onboard from a locked snapshot"
+    await expect(service.preview("snap-2026-draft", 2027)).rejects.toThrow(SourceNotLockedError);
+  });
+
+  it("throws NotFoundError when snapshot does not exist", async () => {
+    prisma.snapshot.findUniqueOrThrow.mockRejectedValue(
+      Object.assign(new Error("No Snapshot found"), { code: "P2025" })
+    );
+
+    await expect(service.preview("missing", 2027)).rejects.toThrow(NotFoundError);
+  });
+
+  it("filters source values to active line items only", async () => {
+    await service.preview("snap-2026", 2027);
+
+    expect(prisma.value.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { snapshotId: "snap-2026", lineItem: { isActive: true } }
+      })
     );
   });
 
@@ -498,7 +515,7 @@ describe("TemplateService.onboard", () => {
     });
   });
 
-  it("throws if source snapshot is not locked", async () => {
+  it("throws SourceNotLockedError if source snapshot is not locked", async () => {
     prisma.snapshot.findUniqueOrThrow.mockResolvedValue(MOCK_DRAFT_SNAPSHOT);
 
     await expect(
@@ -508,7 +525,22 @@ describe("TemplateService.onboard", () => {
         targetYear: 2027,
         createdBy: "user-1"
       })
-    ).rejects.toThrow("Can only onboard from a locked snapshot");
+    ).rejects.toThrow(SourceNotLockedError);
+  });
+
+  it("filters source values to active line items only", async () => {
+    await service.onboard({
+      sourceSnapshotId: "snap-2026",
+      name: "2027 CF",
+      targetYear: 2027,
+      createdBy: "user-1"
+    });
+
+    expect(prisma.value.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { snapshotId: "snap-2026", lineItem: { isActive: true } }
+      })
+    );
   });
 
   it("logs an audit entry on successful onboarding", async () => {
@@ -672,7 +704,7 @@ describe("template http-handlers", () => {
 
     it("returns 409 for unlocked snapshot", async () => {
       const handler = await getHandler();
-      mockService.preview.mockRejectedValue(new Error("Can only onboard from a locked snapshot"));
+      mockService.preview.mockRejectedValue(new SourceNotLockedError());
 
       const result = await handler(mockService, {
         sourceSnapshotId: "snap-1",
@@ -736,7 +768,7 @@ describe("template http-handlers", () => {
 
     it("returns 404 for missing source snapshot", async () => {
       const handler = await getHandler();
-      mockService.onboard.mockRejectedValue(new Error("No Snapshot found"));
+      mockService.onboard.mockRejectedValue(new NotFoundError("Snapshot not found"));
 
       const result = await handler(mockService, {
         sourceSnapshotId: "not-real",
@@ -750,7 +782,7 @@ describe("template http-handlers", () => {
 
     it("returns 409 for draft source snapshot", async () => {
       const handler = await getHandler();
-      mockService.onboard.mockRejectedValue(new Error("Can only onboard from a locked snapshot"));
+      mockService.onboard.mockRejectedValue(new SourceNotLockedError());
 
       const result = await handler(mockService, {
         sourceSnapshotId: "snap-draft",


### PR DESCRIPTION
## Summary
- Filter source values by `lineItem.isActive: true` in both `preview()` and `onboard()` to prevent archived line items from being copied to new fiscal year snapshots
- Replace `error.message.includes()` string matching in template HTTP handlers with `instanceof NotFoundError` / `instanceof SourceNotLockedError`
- Service now throws typed errors consistent with all other service modules

## Test plan
- [x] 430 tests passing (+3 new)
- [x] New test: preview filters source values with `isActive: true`
- [x] New test: onboard filters source values with `isActive: true`
- [x] New test: preview throws `NotFoundError` for missing snapshot
- [x] Existing handler tests updated to throw typed errors

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)