### PR TITLE
fix: add environment variable validation at startup

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import "./env"; // fail fast if DATABASE_URL is missing
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+/**
+ * Validate required environment variables at module load time.
+ *
+ * Importing this module will throw immediately if any required variable
+ * is missing or malformed, preventing cryptic runtime errors later.
+ */
+
+const serverSchema = z.object({
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  CLERK_SECRET_KEY: z.string().min(1, "CLERK_SECRET_KEY is required"),
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is required")
+});
+
+function validateEnv() {
+  const result = serverSchema.safeParse(process.env);
+  if (!result.success) {
+    const missing = result.error.issues.map((i) => i.message).join(", ");
+    throw new Error(`Environment validation failed: ${missing}`);
+  }
+  return result.data;
+}
+
+export const env = validateEnv();

--- a/tests/unit/env-validation.test.ts
+++ b/tests/unit/env-validation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+
+/**
+ * Test the env validation logic without importing the module (which
+ * would attempt to parse process.env immediately). Instead, we replicate
+ * the schema and test it directly.
+ */
+
+const serverSchema = z.object({
+  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+  CLERK_SECRET_KEY: z.string().min(1, "CLERK_SECRET_KEY is required"),
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().min(1, "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is required")
+});
+
+describe("env validation schema", () => {
+  it("accepts valid env vars", () => {
+    const result = serverSchema.safeParse({
+      DATABASE_URL: "postgresql://localhost:5432/cashflow",
+      CLERK_SECRET_KEY: "sk_test_abc123",
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_xyz789"
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing DATABASE_URL", () => {
+    const result = serverSchema.safeParse({
+      CLERK_SECRET_KEY: "sk_test_abc123",
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_xyz789"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing CLERK_SECRET_KEY", () => {
+    const result = serverSchema.safeParse({
+      DATABASE_URL: "postgresql://localhost:5432/cashflow",
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_xyz789"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", () => {
+    const result = serverSchema.safeParse({
+      DATABASE_URL: "postgresql://localhost:5432/cashflow",
+      CLERK_SECRET_KEY: "sk_test_abc123"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty string values", () => {
+    const result = serverSchema.safeParse({
+      DATABASE_URL: "",
+      CLERK_SECRET_KEY: "sk_test_abc123",
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_xyz789"
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("reports all missing fields in errors", () => {
+    const result = serverSchema.safeParse({});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path[0]);
+      expect(paths).toContain("DATABASE_URL");
+      expect(paths).toContain("CLERK_SECRET_KEY");
+      expect(paths).toContain("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add `lib/env.ts` with Zod schema that validates `DATABASE_URL`, `CLERK_SECRET_KEY`, and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` at module load time
- Wire into `lib/db.ts` so app fails fast with a clear error instead of cryptic Prisma/Clerk failures at first request

## Test plan
- [x] 436 tests passing (+6 new)
- [x] Schema rejects missing fields, empty strings, and partial configs
- [x] Schema accepts valid env var values

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)