### PR TITLE
fix: projection params validation and field length limits

### DIFF
--- a/lib/validations/bulk-schemas.ts
+++ b/lib/validations/bulk-schemas.ts
@@ -12,7 +12,7 @@ export const bulkUpdateSchema = z
     operation: bulkOperationSchema,
     operand: z.number().finite("operand must be a finite number"),
     preview: z.boolean().optional(),
-    reason: z.string().trim().min(1).optional(),
+    reason: z.string().trim().min(1).max(1000).optional(),
     updatedBy: z.string().trim().optional()
   })
   .refine((d) => d.preview === true || !!d.reason, {
@@ -37,7 +37,7 @@ const restoreEntrySchema = z.object({
 
 export const bulkRestoreSchema = z.object({
   snapshotId: nonEmptyString,
-  reason: nonEmptyString,
+  reason: nonEmptyString.max(1000),
   updatedBy: z.string().trim().optional(),
   restores: z.array(restoreEntrySchema).min(1, "restores array must not be empty")
 });

--- a/lib/validations/group-schemas.ts
+++ b/lib/validations/group-schemas.ts
@@ -17,7 +17,7 @@ export const updateGroupSchema = z
     groupType: groupTypeSchema.optional(),
     sortOrder: z.number().int().min(0).optional(),
     updatedBy: z.string().trim().optional(),
-    reason: z.string().trim().optional()
+    reason: z.string().trim().max(1000).optional()
   })
   .refine((d) => d.name !== undefined || d.groupType !== undefined || d.sortOrder !== undefined, {
     message: "No updatable fields provided"
@@ -26,5 +26,5 @@ export const updateGroupSchema = z
 export const archiveGroupSchema = z.object({
   groupId: nonEmptyString,
   archivedBy: z.string().trim().optional(),
-  reason: z.string().trim().optional()
+  reason: z.string().trim().max(1000).optional()
 });

--- a/lib/validations/line-item-schemas.ts
+++ b/lib/validations/line-item-schemas.ts
@@ -9,14 +9,55 @@ export const projectionMethodSchema = z.enum([
   "custom_formula"
 ]);
 
-export const createLineItemSchema = z.object({
-  groupId: nonEmptyString,
-  label: nonEmptyString,
-  projectionMethod: projectionMethodSchema.optional(),
-  projectionParams: z.record(z.string(), z.unknown()).nullable().optional(),
-  sortOrder: z.number().int().min(0).optional(),
-  createdBy: z.string().trim().optional()
+/** Per-method projection params schemas */
+const annualSpreadParamsSchema = z.object({
+  annualTotal: z.string().regex(/^-?\d+(\.\d{1,2})?$/, "annualTotal must be a decimal string")
 });
+
+const priorYearPctParamsSchema = z.object({
+  pctChange: z.number().min(-100).max(1000)
+});
+
+const emptyParamsSchema = z.object({}).passthrough();
+
+/**
+ * Validates projectionParams based on the projectionMethod.
+ * Falls back to a permissive record if method is not provided (create defaults to manual).
+ */
+export function validateProjectionParams(
+  method: string | undefined,
+  params: unknown
+): boolean {
+  if (params === null || params === undefined) return true;
+  switch (method) {
+    case "annual_spread":
+      return annualSpreadParamsSchema.safeParse(params).success;
+    case "prior_year_pct":
+      return priorYearPctParamsSchema.safeParse(params).success;
+    case "manual":
+    case "prior_year_flat":
+    case "custom_formula":
+      return emptyParamsSchema.safeParse(params).success;
+    default:
+      return z.record(z.string(), z.unknown()).safeParse(params).success;
+  }
+}
+
+export const projectionParamsSchema = z.record(z.string(), z.unknown()).nullable().optional();
+
+export const createLineItemSchema = z
+  .object({
+    groupId: nonEmptyString,
+    label: nonEmptyString,
+    projectionMethod: projectionMethodSchema.optional(),
+    projectionParams: projectionParamsSchema,
+    sortOrder: z.number().int().min(0).optional(),
+    createdBy: z.string().trim().optional()
+  })
+  .refine(
+    (d) => validateProjectionParams(d.projectionMethod, d.projectionParams),
+    { message: "projectionParams invalid for the selected projectionMethod" }
+  );
 
 export const updateLineItemSchema = z
   .object({
@@ -24,10 +65,10 @@ export const updateLineItemSchema = z
     groupId: nonEmptyString.optional(),
     label: nonEmptyString.optional(),
     projectionMethod: projectionMethodSchema.optional(),
-    projectionParams: z.record(z.string(), z.unknown()).nullable().optional(),
+    projectionParams: projectionParamsSchema,
     sortOrder: z.number().int().min(0).optional(),
     updatedBy: z.string().trim().optional(),
-    reason: z.string().trim().optional()
+    reason: z.string().trim().max(1000).optional()
   })
   .refine(
     (d) =>
@@ -37,10 +78,14 @@ export const updateLineItemSchema = z
       d.projectionParams !== undefined ||
       d.sortOrder !== undefined,
     { message: "No updatable fields provided" }
+  )
+  .refine(
+    (d) => validateProjectionParams(d.projectionMethod, d.projectionParams),
+    { message: "projectionParams invalid for the selected projectionMethod" }
   );
 
 export const archiveLineItemSchema = z.object({
   lineItemId: nonEmptyString,
   archivedBy: z.string().trim().optional(),
-  reason: z.string().trim().optional()
+  reason: z.string().trim().max(1000).optional()
 });

--- a/lib/validations/snapshot-schemas.ts
+++ b/lib/validations/snapshot-schemas.ts
@@ -10,13 +10,13 @@ export const createSnapshotSchema = z.object({
 export const lockSnapshotSchema = z.object({
   snapshotId: nonEmptyString,
   lockedBy: nonEmptyString,
-  reason: z.string().trim().optional()
+  reason: z.string().trim().max(1000).optional()
 });
 
 export const unlockSnapshotSchema = z.object({
   snapshotId: nonEmptyString,
   unlockedBy: nonEmptyString,
-  reason: z.string().trim().optional()
+  reason: z.string().trim().max(1000).optional()
 });
 
 export const copySnapshotSchema = z.object({

--- a/lib/validations/value-schemas.ts
+++ b/lib/validations/value-schemas.ts
@@ -15,7 +15,7 @@ export const upsertValueSchema = z.object({
     .regex(/^-?\d+(\.\d{1,2})?$/, "must be a valid decimal amount")
     .nullable()
     .optional(),
-  note: z.string().nullable().optional(),
+  note: z.string().max(1000).nullable().optional(),
   updatedBy: z.string().optional(),
-  reason: z.string().trim().optional()
+  reason: z.string().trim().max(1000).optional()
 });


### PR DESCRIPTION
## Summary
- Add discriminated Zod schemas for `projectionParams` per method type: `annual_spread` requires `annualTotal` (decimal string), `prior_year_pct` requires `pctChange` (number -100 to 1000)
- Add `.max(1000)` to all `note` and `reason` fields across group, snapshot, line-item, value, and bulk validation schemas
- Dev auth bypass was already guarded with `NODE_ENV !== "production"` check

## Test plan
- [x] 436 tests passing — no regressions
- [ ] Manual: verify `annual_spread` without `annualTotal` returns 400
- [ ] Manual: verify reason field >1000 chars returns 400

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)