### PR TITLE
improve: frontend accessibility and performance in data grid

### DIFF
--- a/components/bulk-update/BulkUpdatePanel.tsx
+++ b/components/bulk-update/BulkUpdatePanel.tsx
@@ -147,9 +147,9 @@ export function BulkUpdatePanel({ snapshotId, groups, onClose, onSuccess }: Bulk
 
   return (
     <div className="bu-overlay">
-      <div className="bu-panel" role="dialog" aria-modal="true" aria-label="Bulk update">
+      <div className="bu-panel" role="dialog" aria-modal="true" aria-labelledby="bu-panel-title">
         <div className="bu-panel-header">
-          <h3 className="bu-panel-title">Bulk Update</h3>
+          <h3 className="bu-panel-title" id="bu-panel-title">Bulk Update</h3>
           <button className="ghost-btn bu-close" onClick={onClose} type="button">
             &times;
           </button>
@@ -179,6 +179,7 @@ export function BulkUpdatePanel({ snapshotId, groups, onClose, onSuccess }: Bulk
                 className={`ghost-btn${field === "projected" ? " bu-toggle-active" : ""}`}
                 onClick={() => setField("projected")}
                 type="button"
+                aria-pressed={field === "projected"}
               >
                 Projected
               </button>
@@ -186,6 +187,7 @@ export function BulkUpdatePanel({ snapshotId, groups, onClose, onSuccess }: Bulk
                 className={`ghost-btn${field === "actual" ? " bu-toggle-active" : ""}`}
                 onClick={() => setField("actual")}
                 type="button"
+                aria-pressed={field === "actual"}
               >
                 Actual
               </button>
@@ -199,6 +201,7 @@ export function BulkUpdatePanel({ snapshotId, groups, onClose, onSuccess }: Bulk
                 className={`ghost-btn${operation === "multiply" ? " bu-toggle-active" : ""}`}
                 onClick={() => setOperation("multiply")}
                 type="button"
+                aria-pressed={operation === "multiply"}
               >
                 % Change
               </button>
@@ -206,6 +209,7 @@ export function BulkUpdatePanel({ snapshotId, groups, onClose, onSuccess }: Bulk
                 className={`ghost-btn${operation === "add" ? " bu-toggle-active" : ""}`}
                 onClick={() => setOperation("add")}
                 type="button"
+                aria-pressed={operation === "add"}
               >
                 Flat Adjust
               </button>

--- a/components/data-grid/CashFlowGrid.tsx
+++ b/components/data-grid/CashFlowGrid.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, memo } from "react";
 import type { GridData, GridGroup, GridRow, PendingEdit } from "./types";
 import { formatCurrency, formatPeriodLabel, parseCurrencyInput } from "./types";
 
@@ -19,9 +19,9 @@ export function CashFlowGrid({ data, editable, onCellChange, viewMode }: CashFlo
   const canEdit = editable && !isLocked;
 
   return (
-    <div className="cf-grid-wrapper">
+    <div className="cf-grid-wrapper" role="region" aria-label="Cash flow data grid">
       <div className="cf-grid-scroll">
-        <table className="cf-grid">
+        <table className="cf-grid" role="grid">
           <thead>
             <tr>
               <th className="cf-grid-label-col cf-grid-sticky-col">Line Item</th>
@@ -83,11 +83,11 @@ interface GroupSectionProps {
   onCellChange?: (edit: PendingEdit) => void;
 }
 
-function GroupSection({ group, periods, canEdit, viewMode, onCellChange }: GroupSectionProps) {
+const GroupSection = memo(function GroupSection({ group, periods, canEdit, viewMode, onCellChange }: GroupSectionProps) {
   return (
     <>
-      <tr className="cf-grid-group-header">
-        <td className="cf-grid-sticky-col" colSpan={1}>
+      <tr className="cf-grid-group-header" role="row">
+        <td className="cf-grid-sticky-col" colSpan={1} role="rowheader">
           <span className="cf-grid-group-name">{group.name}</span>
           <span className="cf-grid-group-type">{group.groupType.replace("_", " ")}</span>
         </td>
@@ -109,7 +109,7 @@ function GroupSection({ group, periods, canEdit, viewMode, onCellChange }: Group
       <SubtotalRow group={group} periods={periods} viewMode={viewMode} />
     </>
   );
-}
+});
 
 // ---------------------------------------------------------------------------
 // Line Item Row
@@ -233,6 +233,11 @@ function GridCell({
   const commitEdit = useCallback(() => {
     if (!editing || !onCellChange) return;
     const parsed = parseCurrencyInput(editValue);
+    if (editValue.trim() !== "" && parsed === null) {
+      // Invalid input — revert without committing
+      setEditing(null);
+      return;
+    }
     const current = editing === "projected" ? projected : actual;
     // Only emit if value actually changed
     if (parsed !== current) {
@@ -370,7 +375,7 @@ function GridCell({
   const displayValue = field === "projected" ? projected : actual;
 
   return (
-    <td className={cellClass} onDoubleClick={() => startEdit(field)}>
+    <td className={cellClass} onDoubleClick={() => startEdit(field)} role="gridcell" aria-label={`${field} ${formatPeriodLabel(period)}`}>
       {noteButton}
       {editing === field ? (
         <input
@@ -380,6 +385,7 @@ function GridCell({
           onChange={(e) => setEditValue(e.target.value)}
           onBlur={commitEdit}
           onKeyDown={handleKeyDown}
+          aria-label={`Edit ${field} for ${formatPeriodLabel(period)}`}
         />
       ) : (
         <span className={`cf-grid-val ${canEdit ? "cf-grid-val-editable" : ""}`}>

--- a/components/data-grid/MobileCardView.tsx
+++ b/components/data-grid/MobileCardView.tsx
@@ -93,13 +93,19 @@ function MobileItemCard({
 
   return (
     <div className={`cf-mobile-card${expanded ? " cf-mobile-card-expanded" : ""}`}>
-      <button className="cf-mobile-card-header" onClick={onToggle} type="button">
+      <button
+        className="cf-mobile-card-header"
+        onClick={onToggle}
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={`card-body-${row.lineItemId}`}
+      >
         <span className="cf-mobile-card-label">{row.label}</span>
         <span className="cf-mobile-card-total">{formatCurrency(projTotal.toFixed(2))}</span>
         <span className="cf-mobile-card-chevron">{expanded ? "\u25B2" : "\u25BC"}</span>
       </button>
       {expanded && (
-        <div className="cf-mobile-card-body">
+        <div className="cf-mobile-card-body" id={`card-body-${row.lineItemId}`}>
           {periods.map((p) => {
             const cell = row.values[p] ?? {
               projected: null,


### PR DESCRIPTION
## Summary
- Wrap `GroupSection` in `React.memo` to prevent unnecessary re-renders on parent state changes
- Add ARIA roles (`region`, `grid`, `gridcell`, `rowheader`) to `CashFlowGrid` table
- Add `aria-expanded` / `aria-controls` to mobile card expand/collapse buttons
- Add `aria-labelledby` linking `BulkUpdatePanel` dialog to its title
- Add `aria-pressed` to field/operation toggle buttons in bulk update
- Add `aria-label` to grid input cells for screen reader context
- Validate `parseFloat` results — revert on NaN instead of committing bad data

## Test plan
- [x] 436 tests passing — no regressions
- [ ] Screen reader testing: verify grid cells and mobile cards are announced correctly
- [ ] Verify GroupSection doesn't re-render when sibling group changes

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)