### PR TITLE
test: stabilize Playwright E2E for CI gating (issue #57)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const PLAYWRIGHT_PORT = process.env.PLAYWRIGHT_PORT ?? "3100";
+const PLAYWRIGHT_BASE_URL = `http://localhost:${PLAYWRIGHT_PORT}`;
+
 /**
  * Playwright configuration for smoke tests.
  *
@@ -15,7 +18,7 @@ export default defineConfig({
   reporter: process.env.CI ? "github" : "list",
 
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: PLAYWRIGHT_BASE_URL,
     trace: "retain-on-failure"
   },
 
@@ -27,8 +30,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: "npm run dev",
-    url: "http://localhost:3000",
+    command: `npm run dev -- --port ${PLAYWRIGHT_PORT}`,
+    url: PLAYWRIGHT_BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
     env: {

--- a/tests/e2e/data-grid.spec.ts
+++ b/tests/e2e/data-grid.spec.ts
@@ -34,8 +34,8 @@ test.describe("data grid — draft snapshot", () => {
     await page.goto("/snapshots/snap-draft");
     await expect(page.locator("table.cf-grid")).toBeVisible({ timeout: 10_000 });
 
-    await expect(page.getByText("Rental Income")).toBeVisible();
-    await expect(page.getByText("Operating Expenses")).toBeVisible();
+    await expect(page.locator(".cf-grid-group-name", { hasText: "Rental Income" })).toBeVisible();
+    await expect(page.locator(".cf-grid-group-name", { hasText: "Operating Expenses" })).toBeVisible();
   });
 
   test("renders line item labels", async ({ page }) => {
@@ -51,8 +51,8 @@ test.describe("data grid — draft snapshot", () => {
     await page.goto("/snapshots/snap-draft");
     await expect(page.locator("table.cf-grid")).toBeVisible({ timeout: 10_000 });
 
-    // Base Rent projected = $10,000 per month
-    await expect(page.getByText("$10,000")).toBeVisible();
+    // Base Rent projected = 10,000 per month
+    await expect(page.getByText("10,000")).toBeVisible();
   });
 
   test("renders subtotal rows", async ({ page }) => {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -17,12 +17,22 @@ async function mockSnapshotsApi(page: import("@playwright/test").Page) {
     route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({
-        data: [
-          { id: "snap-1", name: "FY2026 Draft", status: "draft", asOfMonth: "2026-01-01" },
-          { id: "snap-2", name: "FY2025 Locked", status: "locked", asOfMonth: "2025-01-01" }
-        ]
-      })
+      body: JSON.stringify([
+        {
+          id: "snap-1",
+          name: "FY2026 Draft",
+          status: "draft",
+          asOfMonth: "2026-01-01T00:00:00.000Z",
+          createdAt: "2026-01-15T10:00:00Z"
+        },
+        {
+          id: "snap-2",
+          name: "FY2025 Locked",
+          status: "locked",
+          asOfMonth: "2025-01-01T00:00:00.000Z",
+          createdAt: "2025-06-01T10:00:00Z"
+        }
+      ])
     });
   });
 }


### PR DESCRIPTION
## Summary

- Issue: Closes #57
- Scope: Stabilize Playwright E2E execution in CI/local by pinning Playwright web server port and updating stale E2E selectors/mocked payload shapes.

## Review Findings

- [x] Reviewer findings captured (or "No findings")
- [ ] Findings addressed with follow-up commits

## Validation

- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [x] `npm run test:ci`
- [ ] `npm run build`

## Tests

- [x] Tests added/updated for changed behavior
- [ ] If no tests were added, include justification and add `[no-tests]` token here

## Risk Check

- [x] Backward compatibility assessed
- [x] Security/permission changes assessed
- [x] Data model or migration impact assessed

## Notes for Reviewer

- Focus areas: `playwright.config.ts` webServer/baseURL port behavior and updated selectors in `tests/e2e/*.spec.ts`.
- Known limitations: Local Playwright run is currently blocked in this environment by a Next.js runtime startup error (`__webpack_modules__[moduleId] is not a function`), so E2E green status should be verified in CI.
