### PR TITLE
infra: add global error boundary and custom 404/500 pages (issue #73)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="cf-error-shell">
+      <section className="cf-error-card" role="alert">
+        <p className="cf-error-eyebrow">500</p>
+        <h1 className="cf-error-title">Something went wrong</h1>
+        <p className="cf-error-copy">
+          We could not complete this request. Retry the action or refresh the page.
+        </p>
+        <div className="cf-error-actions">
+          <button className="cf-error-button" onClick={reset} type="button">
+            Retry
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import { useEffect } from "react";
+
+type GlobalErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalErrorPage({ error, reset }: GlobalErrorPageProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <main className="cf-error-shell">
+          <section className="cf-error-card" role="alert">
+            <p className="cf-error-eyebrow">Critical error</p>
+            <h1 className="cf-error-title">Application failed to load</h1>
+            <p className="cf-error-copy">
+              We captured this error. Retry loading the app, or go back to the dashboard.
+            </p>
+            <div className="cf-error-actions">
+              <button className="cf-error-button" onClick={reset} type="button">
+                Retry
+              </button>
+              <Link className="cf-error-link" href="/">
+                Go home
+              </Link>
+            </div>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -402,3 +402,88 @@ select {
     align-items: flex-start;
   }
 }
+
+.cf-error-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(14, 116, 144, 0.1), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(239, 68, 68, 0.08), transparent 30%),
+    #f8fafc;
+}
+
+.cf-error-card {
+  width: min(100%, 40rem);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+}
+
+.cf-error-eyebrow {
+  margin: 0;
+  color: #0f766e;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.cf-error-title {
+  margin: 0.75rem 0 0;
+  color: #0f172a;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+}
+
+.cf-error-copy {
+  margin: 0.9rem 0 0;
+  color: #334155;
+  line-height: 1.6;
+}
+
+.cf-error-actions {
+  margin-top: 1.4rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cf-error-button,
+.cf-error-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0.55rem;
+  min-height: 2.5rem;
+  padding: 0.55rem 1rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cf-error-button {
+  background: #0f766e;
+  color: #ffffff;
+  border: 1px solid #0f766e;
+  cursor: pointer;
+}
+
+.cf-error-link {
+  color: #0f172a;
+  background: #e2e8f0;
+  border: 1px solid #cbd5e1;
+}
+
+.cf-error-link-primary {
+  color: #ffffff;
+  background: #0f766e;
+  border-color: #0f766e;
+}
+
+.cf-error-button:hover,
+.cf-error-link:hover {
+  filter: brightness(0.97);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
+import { AppErrorBoundary } from "@/components/error/AppErrorBoundary";
 import { isDevAuthBypassEnabled } from "@/lib/auth/dev-bypass";
 import "./globals.css";
 
@@ -16,7 +17,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
   if (isDevAuthBypassEnabled()) {
     return (
       <html lang="en">
-        <body>{children}</body>
+        <body>
+          <AppErrorBoundary>{children}</AppErrorBoundary>
+        </body>
       </html>
     );
   }
@@ -24,7 +27,9 @@ export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <ClerkProvider>
       <html lang="en">
-        <body>{children}</body>
+        <body>
+          <AppErrorBoundary>{children}</AppErrorBoundary>
+        </body>
       </html>
     </ClerkProvider>
   );

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <main className="cf-error-shell">
+      <section className="cf-error-card">
+        <p className="cf-error-eyebrow">404</p>
+        <h1 className="cf-error-title">Page not found</h1>
+        <p className="cf-error-copy">
+          The page you requested does not exist or may have moved.
+        </p>
+        <div className="cf-error-actions">
+          <Link className="cf-error-link cf-error-link-primary" href="/">
+            Go home
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/error/AppErrorBoundary.tsx
+++ b/components/error/AppErrorBoundary.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+
+type AppErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = {
+    hasError: false
+  };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    Sentry.captureException(error, {
+      extra: {
+        componentStack: errorInfo.componentStack
+      }
+    });
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false });
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <main className="cf-error-shell">
+        <section className="cf-error-card" role="alert">
+          <p className="cf-error-eyebrow">Unexpected error</p>
+          <h1 className="cf-error-title">Something went wrong</h1>
+          <p className="cf-error-copy">
+            We hit a rendering error while loading this page. Try again, or return to the dashboard.
+          </p>
+          <div className="cf-error-actions">
+            <button className="cf-error-button" onClick={this.handleRetry} type="button">
+              Try again
+            </button>
+            <Link className="cf-error-link" href="/">
+              Go home
+            </Link>
+          </div>
+        </section>
+      </main>
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Issue: Closes #73
- Scope:
  - Add app-level React error boundary wrapper (`AppErrorBoundary`) around root layout children.
  - Add custom App Router error pages: `app/not-found.tsx`, `app/error.tsx`, `app/global-error.tsx`.
  - Capture boundary/runtime errors to Sentry from both class boundary and route-level error components.
  - Add shared polished error-page styling in `app/globals.css`.

## Review Findings

- [x] Reviewer findings captured (or "No findings")
- [ ] Findings addressed with follow-up commits

## Validation

- [ ] `npm run lint` (blocked by pre-existing lint error in `lib/snapshots/compare-service.ts:165`)
- [x] `npm run typecheck`
- [x] `npm run test:ci`
- [ ] `npm run build`

## Tests

- [ ] Tests added/updated for changed behavior
- [x] If no tests were added, include justification and add `[no-tests]` token here

[no-tests] Error-page behavior is framework-integrated (Next.js App Router boundary resolution) and current test setup is node-only without client/DOM harness for boundary rendering.

## Risk Check

- [x] Backward compatibility assessed
- [x] Security/permission changes assessed
- [x] Data model or migration impact assessed

## Notes for Reviewer

- Focus areas:
  - Boundary wrap in `app/layout.tsx`
  - Sentry capture paths in `components/error/AppErrorBoundary.tsx`, `app/error.tsx`, and `app/global-error.tsx`
- Known limitations:
  - Existing repo lint error unrelated to this issue currently fails `npm run lint`.
