### PR TITLE
feat: integrate error boundary and custom 404/500 pages (#73)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+type ErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="cf-error-shell">
+      <section className="cf-error-card" role="alert">
+        <p className="cf-error-eyebrow">500</p>
+        <h1 className="cf-error-title">Something went wrong</h1>
+        <p className="cf-error-copy">
+          We could not complete this request. Retry the action or refresh the page.
+        </p>
+        <div className="cf-error-actions">
+          <button className="cf-error-button" onClick={reset} type="button">
+            Retry
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import { useEffect } from "react";
+
+type GlobalErrorPageProps = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalErrorPage({ error, reset }: GlobalErrorPageProps) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <main className="cf-error-shell">
+          <section className="cf-error-card" role="alert">
+            <p className="cf-error-eyebrow">Critical error</p>
+            <h1 className="cf-error-title">Application failed to load</h1>
+            <p className="cf-error-copy">
+              We captured this error. Retry loading the app, or go back to the dashboard.
+            </p>
+            <div className="cf-error-actions">
+              <button className="cf-error-button" onClick={reset} type="button">
+                Retry
+              </button>
+              <Link className="cf-error-link" href="/">
+                Go home
+              </Link>
+            </div>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -963,3 +963,97 @@ select:focus {
     bottom: 1rem;
   }
 }
+
+/* ======================================================================
+   Error Pages (404, 500, boundary)
+   ====================================================================== */
+.cf-error-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem;
+  background: var(--bg);
+}
+
+.cf-error-card {
+  width: min(100%, 40rem);
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 2.5rem;
+}
+
+.cf-error-eyebrow {
+  margin: 0;
+  color: var(--primary);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.cf-error-title {
+  margin: 0.75rem 0 0;
+  color: var(--ink);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+}
+
+.cf-error-copy {
+  margin: 0.9rem 0 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cf-error-actions {
+  margin-top: 1.4rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cf-error-button,
+.cf-error-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  min-height: 2.5rem;
+  padding: 0.55rem 1rem;
+  text-decoration: none;
+  font-weight: 600;
+  transition: all var(--transition);
+}
+
+.cf-error-button {
+  background: var(--primary);
+  color: #ffffff;
+  border: 1px solid var(--primary);
+  cursor: pointer;
+}
+
+.cf-error-button:hover {
+  background: var(--primary-hover);
+}
+
+.cf-error-link {
+  color: var(--ink);
+  background: var(--primary-light);
+  border: 1px solid var(--line);
+}
+
+.cf-error-link:hover {
+  background: #dde8ff;
+}
+
+.cf-error-link-primary {
+  color: #ffffff;
+  background: var(--primary);
+  border-color: var(--primary);
+}
+
+.cf-error-link-primary:hover {
+  background: var(--primary-hover);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
+import { AppErrorBoundary } from "@/components/error/AppErrorBoundary";
 import { isDevAuthBypassEnabled } from "@/lib/auth/dev-bypass";
 import { NavBar } from "@/components/ui/NavBar";
 import { ToastProvider } from "@/components/ui/Toast";
@@ -16,10 +17,10 @@ type RootLayoutProps = Readonly<{
 
 function AppShell({ children }: { children: React.ReactNode }) {
   return (
-    <>
+    <AppErrorBoundary>
       <NavBar />
       <ToastProvider>{children}</ToastProvider>
-    </>
+    </AppErrorBoundary>
   );
 }
 

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function NotFoundPage() {
+  return (
+    <main className="cf-error-shell">
+      <section className="cf-error-card">
+        <p className="cf-error-eyebrow">404</p>
+        <h1 className="cf-error-title">Page not found</h1>
+        <p className="cf-error-copy">
+          The page you requested does not exist or may have moved.
+        </p>
+        <div className="cf-error-actions">
+          <Link className="cf-error-link cf-error-link-primary" href="/">
+            Go home
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/error/AppErrorBoundary.tsx
+++ b/components/error/AppErrorBoundary.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import Link from "next/link";
+import type { ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+
+type AppErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type AppErrorBoundaryState = {
+  hasError: boolean;
+};
+
+export class AppErrorBoundary extends Component<AppErrorBoundaryProps, AppErrorBoundaryState> {
+  state: AppErrorBoundaryState = {
+    hasError: false
+  };
+
+  static getDerivedStateFromError(): AppErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    Sentry.captureException(error, {
+      extra: {
+        componentStack: errorInfo.componentStack
+      }
+    });
+  }
+
+  private handleRetry = (): void => {
+    this.setState({ hasError: false });
+  };
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    return (
+      <main className="cf-error-shell">
+        <section className="cf-error-card" role="alert">
+          <p className="cf-error-eyebrow">Unexpected error</p>
+          <h1 className="cf-error-title">Something went wrong</h1>
+          <p className="cf-error-copy">
+            We hit a rendering error while loading this page. Try again, or return to the dashboard.
+          </p>
+          <div className="cf-error-actions">
+            <button className="cf-error-button" onClick={this.handleRetry} type="button">
+              Try again
+            </button>
+            <Link className="cf-error-link" href="/">
+              Go home
+            </Link>
+          </div>
+        </section>
+      </main>
+    );
+  }
+}

--- a/lib/snapshots/compare-service.ts
+++ b/lib/snapshots/compare-service.ts
@@ -160,9 +160,8 @@ export class CompareService {
       return v.toString();
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const compareGroups: CompareGroupData[] = groups
-      .map((group: any) => {
+      .map((group) => {
         const groupLineItems = Array.from(lineItemsById.values())
           .filter((li) => li.groupId === group.id)
           .sort((a, b) => a.sortOrder - b.sortOrder);


### PR DESCRIPTION
## Summary
Integrates Codex's error page work (PR #81) on top of the updated UI layout from PR #80.

- **AppErrorBoundary** wraps the full app shell (NavBar + ToastProvider + children)
- **404 page** (`not-found.tsx`) — clean "Page not found" with "Go home" link
- **500 page** (`error.tsx`) — "Something went wrong" with retry button + Sentry capture
- **Global error** (`global-error.tsx`) — root layout fallback with retry + home links
- Error page styles use our design tokens (not hardcoded colors)
- Fixed `no-explicit-any` lint warning in `compare-service.ts`

Closes #73

## Test plan
- [x] All 441 unit/integration tests pass
- [x] Lint passes (no-explicit-any fixed)
- [ ] Visit `/nonexistent-page` to verify 404
- [ ] Verify error boundary renders on thrown errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)