### PR TITLE
infra: add security headers, API rate limiting, and health endpoint (#74)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({
+    status: "ok",
+    timestamp: new Date().toISOString()
+  });
+}

--- a/lib/security/rate-limiter.ts
+++ b/lib/security/rate-limiter.ts
@@ -1,0 +1,73 @@
+type RateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: number;
+  retryAfterSeconds: number;
+};
+
+type InMemoryRateLimiter = {
+  check: (key: string, now?: number) => RateLimitResult;
+};
+
+type RateLimiterOptions = {
+  limit: number;
+  windowMs: number;
+};
+
+type Bucket = {
+  count: number;
+  resetAt: number;
+};
+
+function createResult(allowed: boolean, bucket: Bucket, limit: number, now: number): RateLimitResult {
+  return {
+    allowed,
+    limit,
+    remaining: Math.max(0, limit - bucket.count),
+    resetAt: bucket.resetAt,
+    retryAfterSeconds: Math.max(0, Math.ceil((bucket.resetAt - now) / 1000))
+  };
+}
+
+export function createInMemoryRateLimiter(options: RateLimiterOptions): InMemoryRateLimiter {
+  const { limit, windowMs } = options;
+  const buckets = new Map<string, Bucket>();
+
+  return {
+    check(key: string, now = Date.now()): RateLimitResult {
+      const current = buckets.get(key);
+
+      if (!current || now >= current.resetAt) {
+        const next: Bucket = { count: 1, resetAt: now + windowMs };
+        buckets.set(key, next);
+        return createResult(true, next, limit, now);
+      }
+
+      if (current.count >= limit) {
+        return createResult(false, current, limit, now);
+      }
+
+      current.count += 1;
+      return createResult(true, current, limit, now);
+    }
+  };
+}
+
+export function getClientIp(headers: Headers): string {
+  const forwardedFor = headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const first = forwardedFor.split(",")[0]?.trim();
+    if (first) return first;
+  }
+
+  const realIp = headers.get("x-real-ip");
+  if (realIp) return realIp;
+
+  return "unknown";
+}
+
+export const apiRateLimiter = createInMemoryRateLimiter({
+  limit: 60,
+  windowMs: 60_000
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import { isDevAuthBypassEnabled } from "./lib/auth/dev-bypass";
+import { apiRateLimiter, getClientIp } from "./lib/security/rate-limiter";
 
 const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)"]);
 
@@ -10,12 +11,51 @@ const clerkAuthMiddleware = clerkMiddleware(async (auth, request) => {
   }
 });
 
+function setRateLimitHeaders(response: NextResponse, remaining: number, resetAt: number): void {
+  response.headers.set("X-RateLimit-Limit", "60");
+  response.headers.set("X-RateLimit-Remaining", String(remaining));
+  response.headers.set("X-RateLimit-Reset", String(Math.floor(resetAt / 1000)));
+}
+
 export default function middleware(request: NextRequest, event: NextFetchEvent) {
-  if (isDevAuthBypassEnabled()) {
-    return NextResponse.next();
+  const isApiRoute = request.nextUrl.pathname.startsWith("/api/");
+  const rateLimit = isApiRoute ? apiRateLimiter.check(getClientIp(request.headers)) : null;
+
+  if (rateLimit && !rateLimit.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(rateLimit.retryAfterSeconds),
+          "X-RateLimit-Limit": String(rateLimit.limit),
+          "X-RateLimit-Remaining": String(rateLimit.remaining),
+          "X-RateLimit-Reset": String(Math.floor(rateLimit.resetAt / 1000))
+        }
+      }
+    );
   }
 
-  return clerkAuthMiddleware(request, event);
+  if (isDevAuthBypassEnabled()) {
+    const response = NextResponse.next();
+    if (rateLimit) {
+      setRateLimitHeaders(response, rateLimit.remaining, rateLimit.resetAt);
+    }
+    return response;
+  }
+
+  const response = clerkAuthMiddleware(request, event);
+  if (
+    rateLimit &&
+    typeof response === "object" &&
+    response !== null &&
+    "headers" in response &&
+    response.headers instanceof Headers
+  ) {
+    setRateLimitHeaders(response as NextResponse, rateLimit.remaining, rateLimit.resetAt);
+  }
+
+  return response;
 }
 
 export const config = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,7 +2,34 @@ import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
 const nextConfig: NextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  async headers() {
+    const csp = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "frame-ancestors 'none'",
+      "object-src 'none'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.com https://*.clerk.accounts.dev https://browser.sentry-cdn.com",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https://*.clerk.com https://*.clerk.accounts.dev https://*.sentry.io",
+      "frame-src https://*.clerk.com https://*.clerk.accounts.dev",
+      "worker-src 'self' blob:"
+    ].join("; ");
+
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Content-Security-Policy", value: csp },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" }
+        ]
+      }
+    ];
+  }
 };
 
 export default withSentryConfig(nextConfig, {

--- a/tests/unit/health-api.test.ts
+++ b/tests/unit/health-api.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { GET } from "@/app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns ok status with ISO timestamp", async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+    expect(typeof body.timestamp).toBe("string");
+    expect(Number.isNaN(Date.parse(body.timestamp))).toBe(false);
+  });
+});

--- a/tests/unit/middleware.test.ts
+++ b/tests/unit/middleware.test.ts
@@ -7,6 +7,14 @@ const mocks = vi.hoisted(() => ({
   routeMatcher: vi.fn(),
   clerkRunner: vi.fn(() => ({ type: "clerk-response" })),
   protect: vi.fn(),
+  getClientIp: vi.fn(() => "127.0.0.1"),
+  rateCheck: vi.fn(() => ({
+    allowed: true,
+    limit: 60,
+    remaining: 59,
+    resetAt: Date.now() + 60_000,
+    retryAfterSeconds: 60
+  })),
   capturedHandler: null as null | ((auth: { protect: () => Promise<void> }, req: unknown) => Promise<void>)
 }));
 
@@ -14,9 +22,17 @@ vi.mock("@/lib/auth/dev-bypass", () => ({
   isDevAuthBypassEnabled: mocks.isDevAuthBypassEnabled
 }));
 
+vi.mock("@/lib/security/rate-limiter", () => ({
+  apiRateLimiter: {
+    check: mocks.rateCheck
+  },
+  getClientIp: mocks.getClientIp
+}));
+
 vi.mock("next/server", () => ({
   NextResponse: {
-    next: mocks.next
+    next: mocks.next,
+    json: vi.fn((body, init) => ({ type: "json-response", body, init }))
   }
 }));
 
@@ -35,6 +51,7 @@ async function loadMiddleware() {
 
 describe("middleware", () => {
   const req = { nextUrl: { pathname: "/dashboard" } } as unknown;
+  const apiReq = { nextUrl: { pathname: "/api/values" }, headers: new Headers() } as unknown;
   const event = {} as never;
 
   beforeEach(() => {
@@ -44,6 +61,13 @@ describe("middleware", () => {
     mocks.isDevAuthBypassEnabled.mockReturnValue(false);
     mocks.routeMatcher.mockReturnValue(false);
     mocks.createRouteMatcher.mockReturnValue(mocks.routeMatcher);
+    mocks.rateCheck.mockReturnValue({
+      allowed: true,
+      limit: 60,
+      remaining: 59,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 60
+    });
   });
 
   it("initializes route matcher with public auth routes", async () => {
@@ -69,6 +93,25 @@ describe("middleware", () => {
     expect(mocks.clerkRunner).toHaveBeenCalledWith(req, event);
     expect(mocks.next).not.toHaveBeenCalled();
     expect(response).toEqual({ type: "clerk-response" });
+  });
+
+  it("returns 429 json response when API rate limit is exceeded", async () => {
+    const middleware = await loadMiddleware();
+    mocks.rateCheck.mockReturnValueOnce({
+      allowed: false,
+      limit: 60,
+      remaining: 0,
+      resetAt: Date.now() + 60_000,
+      retryAfterSeconds: 60
+    });
+
+    const response = middleware(apiReq as never, event);
+    expect(response).toEqual({
+      type: "json-response",
+      body: { error: "Too many requests" },
+      init: expect.objectContaining({ status: 429 })
+    });
+    expect(mocks.clerkRunner).not.toHaveBeenCalled();
   });
 
   it("protects non-public routes in the Clerk auth handler", async () => {

--- a/tests/unit/rate-limiter.test.ts
+++ b/tests/unit/rate-limiter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { createInMemoryRateLimiter, getClientIp } from "@/lib/security/rate-limiter";
+
+describe("createInMemoryRateLimiter", () => {
+  it("allows requests up to the configured limit", () => {
+    const limiter = createInMemoryRateLimiter({ limit: 3, windowMs: 60_000 });
+    const now = Date.now();
+
+    expect(limiter.check("ip-1", now).allowed).toBe(true);
+    expect(limiter.check("ip-1", now + 1).allowed).toBe(true);
+    expect(limiter.check("ip-1", now + 2).allowed).toBe(true);
+  });
+
+  it("blocks requests beyond the configured limit", () => {
+    const limiter = createInMemoryRateLimiter({ limit: 2, windowMs: 60_000 });
+    const now = Date.now();
+
+    limiter.check("ip-1", now);
+    limiter.check("ip-1", now + 1);
+
+    const blocked = limiter.check("ip-1", now + 2);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("resets the window after expiration", () => {
+    const limiter = createInMemoryRateLimiter({ limit: 1, windowMs: 1000 });
+    const now = Date.now();
+
+    limiter.check("ip-1", now);
+    const blocked = limiter.check("ip-1", now + 10);
+    const allowedAfterWindow = limiter.check("ip-1", now + 1100);
+
+    expect(blocked.allowed).toBe(false);
+    expect(allowedAfterWindow.allowed).toBe(true);
+  });
+});
+
+describe("getClientIp", () => {
+  it("uses the first x-forwarded-for entry when present", () => {
+    const headers = new Headers({
+      "x-forwarded-for": "203.0.113.1, 10.0.0.1"
+    });
+    expect(getClientIp(headers)).toBe("203.0.113.1");
+  });
+
+  it("falls back to x-real-ip", () => {
+    const headers = new Headers({
+      "x-real-ip": "198.51.100.9"
+    });
+    expect(getClientIp(headers)).toBe("198.51.100.9");
+  });
+
+  it("returns unknown when no IP headers are present", () => {
+    expect(getClientIp(new Headers())).toBe("unknown");
+  });
+});


### PR DESCRIPTION
## Summary

- Issue: Closes #74
- Scope:
  - Added production security headers via `next.config.ts` (`Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`).
  - Implemented in-memory API rate limiter (60 requests/minute per IP) and enforced it in `middleware.ts` for `/api/*` routes.
  - Added `/api/health` endpoint returning `{ status: "ok", timestamp }`.
  - Added unit tests for rate limiter behavior/IP extraction and health endpoint response.

## Review Findings

- [x] Reviewer findings captured (or "No findings")
- [ ] Findings addressed with follow-up commits

## Validation

- [ ] `npm run lint` (blocked by pre-existing lint error in `lib/snapshots/compare-service.ts:165`)
- [x] `npm run typecheck`
- [x] `npm run test:ci`
- [ ] `npm run build`

## Tests

- [x] Tests added/updated for changed behavior
- [ ] If no tests were added, include justification and add `[no-tests]` token here

## Risk Check

- [x] Backward compatibility assessed
- [x] Security/permission changes assessed
- [x] Data model or migration impact assessed

## Notes for Reviewer

- Focus areas:
  - CSP/header policy in `next.config.ts` and compatibility with Clerk/Sentry.
  - Middleware rate-limiting path (`/api/*`) and 429 response headers.
- Known limitations:
  - Uses in-memory limiter suitable for single-instance runtime; distributed limits would require shared storage.
