### PR TITLE
feat: excel import API with preview/confirm and admin upload UI (#77)

### DIFF
--- a/app/api/imports/excel/route.ts
+++ b/app/api/imports/excel/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import { excelImportService } from "@/lib/imports/service-factory";
+
+export async function POST(request: Request) {
+  const guard = await requireAdmin();
+  if (guard) return guard;
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid multipart form data" }, { status: 400 });
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "Excel file is required" }, { status: 400 });
+  }
+
+  const modeRaw = String(formData.get("mode") ?? "preview").toLowerCase();
+  const mode = modeRaw === "confirm" ? "confirm" : "preview";
+  const snapshotId = String(formData.get("snapshotId") ?? "").trim();
+
+  if (mode === "confirm" && !snapshotId) {
+    return NextResponse.json({ error: "snapshotId is required for confirm mode" }, { status: 400 });
+  }
+
+  if (!file.name.toLowerCase().endsWith(".xlsx")) {
+    return NextResponse.json({ error: "Only .xlsx files are supported" }, { status: 400 });
+  }
+
+  try {
+    const bytes = await file.arrayBuffer();
+    const parsed = await excelImportService.parseWorkbook(Buffer.from(bytes));
+
+    if (mode === "preview") {
+      const summary = excelImportService.summarize(parsed);
+      return NextResponse.json({
+        mode,
+        summary
+      });
+    }
+
+    const summary = await excelImportService.confirmImport(snapshotId, parsed);
+    return NextResponse.json({
+      mode,
+      summary
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Excel import failed";
+    const status = message.includes("not found") || message.includes("locked") ? 400 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/lib/imports/excel-import-service.ts
+++ b/lib/imports/excel-import-service.ts
@@ -1,0 +1,320 @@
+import type { PrismaClient } from "@prisma/client";
+import ExcelJS from "exceljs";
+
+type GroupType = "sector" | "non_operating" | "custom";
+
+type ParsedValue = {
+  period: string;
+  projectedAmount: string;
+};
+
+type ParsedLineItem = {
+  label: string;
+  values: ParsedValue[];
+};
+
+type ParsedGroup = {
+  name: string;
+  groupType: GroupType;
+  lineItems: ParsedLineItem[];
+};
+
+export type ParsedWorkbook = {
+  groups: ParsedGroup[];
+  periods: string[];
+  warnings: string[];
+};
+
+export type PreviewSummary = {
+  groupCount: number;
+  lineItemCount: number;
+  valueCount: number;
+  periods: string[];
+  warnings: string[];
+};
+
+export type ConfirmSummary = PreviewSummary & {
+  snapshotId: string;
+};
+
+function asText(value: ExcelJS.CellValue): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "object") {
+    if ("text" in value && typeof value.text === "string") return value.text.trim();
+    if ("richText" in value && Array.isArray(value.richText)) {
+      return value.richText.map((part) => part.text).join("").trim();
+    }
+    if ("result" in value && value.result !== undefined) {
+      return asText(value.result as ExcelJS.CellValue);
+    }
+  }
+
+  return "";
+}
+
+function excelSerialToDate(serial: number): Date | null {
+  if (!Number.isFinite(serial)) return null;
+  const millis = Math.round((serial - 25569) * 86_400_000);
+  if (!Number.isFinite(millis)) return null;
+  return new Date(millis);
+}
+
+function parsePeriod(value: ExcelJS.CellValue): string | null {
+  if (value === null || value === undefined) return null;
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return `${value.getUTCFullYear()}-${String(value.getUTCMonth() + 1).padStart(2, "0")}`;
+  }
+
+  if (typeof value === "number") {
+    const maybeDate = excelSerialToDate(value);
+    if (maybeDate && !Number.isNaN(maybeDate.getTime())) {
+      return `${maybeDate.getUTCFullYear()}-${String(maybeDate.getUTCMonth() + 1).padStart(2, "0")}`;
+    }
+    return null;
+  }
+
+  if (typeof value === "object" && value !== null && "result" in value) {
+    return parsePeriod(value.result as ExcelJS.CellValue);
+  }
+
+  const raw = asText(value);
+  if (!raw) return null;
+
+  const yyyymm = raw.match(/^(\d{4})[-/](\d{2})/);
+  if (yyyymm) {
+    return `${yyyymm[1]}-${yyyymm[2]}`;
+  }
+
+  const parsed = new Date(`1 ${raw}`);
+  if (!Number.isNaN(parsed.getTime())) {
+    return `${parsed.getUTCFullYear()}-${String(parsed.getUTCMonth() + 1).padStart(2, "0")}`;
+  }
+
+  return null;
+}
+
+function parseProjectedAmount(value: ExcelJS.CellValue): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return value.toFixed(2);
+  if (typeof value === "object" && value !== null && "result" in value) {
+    return parseProjectedAmount(value.result as ExcelJS.CellValue);
+  }
+
+  const raw = asText(value);
+  if (!raw) return null;
+  const normalized = raw
+    .replace(/\$/g, "")
+    .replace(/,/g, "")
+    .replace(/\(([^)]+)\)/, "-$1")
+    .trim();
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return null;
+  return parsed.toFixed(2);
+}
+
+function inferGroupType(sheetName: string): GroupType {
+  const normalized = sheetName.toLowerCase();
+  if (normalized.includes("non-operating") || normalized.includes("non operating")) {
+    return "non_operating";
+  }
+
+  return "sector";
+}
+
+export class ExcelImportService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async parseWorkbook(buffer: Uint8Array): Promise<ParsedWorkbook> {
+    const workbook = new ExcelJS.Workbook();
+    const nodeBuffer = Buffer.from(buffer) as unknown as Parameters<typeof workbook.xlsx.load>[0];
+    await workbook.xlsx.load(nodeBuffer);
+
+    const warnings: string[] = [];
+    const groups: ParsedGroup[] = [];
+    const periodSet = new Set<string>();
+
+    for (const worksheet of workbook.worksheets) {
+      const maxColumns = Math.min(worksheet.columnCount, 120);
+      if (maxColumns < 2) continue;
+
+      const periodColumns = new Map<number, string>();
+      let headerRowNumber: number | null = null;
+
+      for (let rowNum = 1; rowNum <= Math.min(worksheet.rowCount, 25); rowNum++) {
+        const row = worksheet.getRow(rowNum);
+        let matches = 0;
+
+        for (let col = 2; col <= maxColumns; col++) {
+          const period = parsePeriod(row.getCell(col).value);
+          if (period) {
+            matches += 1;
+            periodColumns.set(col, period);
+          }
+        }
+
+        if (matches >= 2) {
+          headerRowNumber = rowNum;
+          break;
+        }
+
+        periodColumns.clear();
+      }
+
+      if (!headerRowNumber || periodColumns.size === 0) {
+        warnings.push(`Sheet "${worksheet.name}" skipped: no period header row detected.`);
+        continue;
+      }
+
+      const parsedLineItems: ParsedLineItem[] = [];
+      for (const period of periodColumns.values()) {
+        periodSet.add(period);
+      }
+
+      for (let rowNum = headerRowNumber + 1; rowNum <= worksheet.rowCount; rowNum++) {
+        const row = worksheet.getRow(rowNum);
+        const label = asText(row.getCell(1).value);
+        if (!label) continue;
+
+        const normalizedLabel = label.toLowerCase();
+        if (normalizedLabel.includes("total") || normalizedLabel.includes("subtotal")) {
+          continue;
+        }
+
+        const values: ParsedValue[] = [];
+        for (const [col, period] of periodColumns.entries()) {
+          const amount = parseProjectedAmount(row.getCell(col).value);
+          if (amount !== null) {
+            values.push({ period, projectedAmount: amount });
+          }
+        }
+
+        if (values.length === 0) continue;
+        parsedLineItems.push({ label, values });
+      }
+
+      if (parsedLineItems.length === 0) {
+        warnings.push(`Sheet "${worksheet.name}" parsed with no line items.`);
+        continue;
+      }
+
+      groups.push({
+        name: worksheet.name.trim(),
+        groupType: inferGroupType(worksheet.name),
+        lineItems: parsedLineItems
+      });
+    }
+
+    const periods = Array.from(periodSet).sort();
+    if (groups.length === 0) {
+      throw new Error("No importable sheets found. Expected period headers and value rows.");
+    }
+
+    return { groups, periods, warnings };
+  }
+
+  summarize(parsed: ParsedWorkbook): PreviewSummary {
+    const lineItemCount = parsed.groups.reduce((acc, g) => acc + g.lineItems.length, 0);
+    const valueCount = parsed.groups.reduce(
+      (acc, g) => acc + g.lineItems.reduce((inner, li) => inner + li.values.length, 0),
+      0
+    );
+
+    return {
+      groupCount: parsed.groups.length,
+      lineItemCount,
+      valueCount,
+      periods: parsed.periods,
+      warnings: parsed.warnings
+    };
+  }
+
+  async confirmImport(snapshotId: string, parsed: ParsedWorkbook): Promise<ConfirmSummary> {
+    const snapshot = await this.prisma.snapshot.findUnique({
+      where: { id: snapshotId },
+      select: { id: true, status: true, createdBy: true }
+    });
+
+    if (!snapshot) {
+      throw new Error(`Snapshot not found: ${snapshotId}`);
+    }
+
+    if (snapshot.status === "locked") {
+      throw new Error("Cannot import into a locked snapshot.");
+    }
+
+    let nextGroupSort = (await this.prisma.group.count()) + 1;
+    const summary = this.summarize(parsed);
+
+    for (const group of parsed.groups) {
+      let groupRecord = await this.prisma.group.findFirst({
+        where: { name: { equals: group.name, mode: "insensitive" } }
+      });
+
+      if (!groupRecord) {
+        groupRecord = await this.prisma.group.create({
+          data: {
+            name: group.name,
+            groupType: group.groupType,
+            sortOrder: nextGroupSort
+          }
+        });
+        nextGroupSort += 1;
+      }
+
+      let nextLineItemSort = (await this.prisma.lineItem.count({ where: { groupId: groupRecord.id } })) + 1;
+      for (const lineItem of group.lineItems) {
+        let lineItemRecord = await this.prisma.lineItem.findFirst({
+          where: {
+            groupId: groupRecord.id,
+            label: { equals: lineItem.label, mode: "insensitive" }
+          }
+        });
+
+        if (!lineItemRecord) {
+          lineItemRecord = await this.prisma.lineItem.create({
+            data: {
+              groupId: groupRecord.id,
+              label: lineItem.label,
+              projectionMethod: "manual",
+              sortOrder: nextLineItemSort
+            }
+          });
+          nextLineItemSort += 1;
+        }
+
+        for (const value of lineItem.values) {
+          await this.prisma.value.upsert({
+            where: {
+              lineItemId_snapshotId_period: {
+                lineItemId: lineItemRecord.id,
+                snapshotId: snapshot.id,
+                period: new Date(`${value.period}-01T00:00:00.000Z`)
+              }
+            },
+            update: {
+              projectedAmount: value.projectedAmount,
+              updatedBy: snapshot.createdBy
+            },
+            create: {
+              lineItemId: lineItemRecord.id,
+              snapshotId: snapshot.id,
+              period: new Date(`${value.period}-01T00:00:00.000Z`),
+              projectedAmount: value.projectedAmount,
+              updatedBy: snapshot.createdBy
+            }
+          });
+        }
+      }
+    }
+
+    return {
+      ...summary,
+      snapshotId
+    };
+  }
+}

--- a/lib/imports/service-factory.ts
+++ b/lib/imports/service-factory.ts
@@ -1,0 +1,4 @@
+import { prisma } from "@/lib/db";
+import { ExcelImportService } from "./excel-import-service";
+
+export const excelImportService = new ExcelImportService(prisma);

--- a/tests/unit/excel-import-route.test.ts
+++ b/tests/unit/excel-import-route.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  requireAdmin: vi.fn(),
+  parseWorkbook: vi.fn(),
+  summarize: vi.fn(),
+  confirmImport: vi.fn()
+}));
+
+vi.mock("@/lib/auth", () => ({
+  requireAdmin: mocks.requireAdmin
+}));
+
+vi.mock("@/lib/imports/service-factory", () => ({
+  excelImportService: {
+    parseWorkbook: mocks.parseWorkbook,
+    summarize: mocks.summarize,
+    confirmImport: mocks.confirmImport
+  }
+}));
+
+import { POST } from "@/app/api/imports/excel/route";
+
+describe("POST /api/imports/excel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.requireAdmin.mockResolvedValue(null);
+  });
+
+  it("returns preview summary in preview mode", async () => {
+    mocks.parseWorkbook.mockResolvedValue({ groups: [], periods: [], warnings: [] });
+    mocks.summarize.mockReturnValue({ groupCount: 1, lineItemCount: 2, valueCount: 3, periods: [], warnings: [] });
+
+    const file = new File([new Uint8Array([1, 2, 3])], "sample.xlsx");
+    const form = new FormData();
+    form.append("file", file);
+    form.append("mode", "preview");
+    form.append("snapshotId", "snap-1");
+
+    const req = new Request("http://localhost/api/imports/excel", { method: "POST", body: form });
+    const res = (await POST(req)) as NextResponse;
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.mode).toBe("preview");
+  });
+
+  it("returns 400 when confirm mode is missing snapshotId", async () => {
+    const file = new File([new Uint8Array([1, 2, 3])], "sample.xlsx");
+    const form = new FormData();
+    form.append("file", file);
+    form.append("mode", "confirm");
+
+    const req = new Request("http://localhost/api/imports/excel", { method: "POST", body: form });
+    const res = (await POST(req)) as NextResponse;
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/unit/excel-import-service.test.ts
+++ b/tests/unit/excel-import-service.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import ExcelJS from "exceljs";
+import type { PrismaClient } from "@prisma/client";
+import { ExcelImportService } from "@/lib/imports/excel-import-service";
+
+async function buildWorkbookBuffer(): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  const ws = workbook.addWorksheet("Residential Properties");
+  ws.addRow(["Line Item", "Jan 2026", "Feb 2026"]);
+  ws.addRow(["Base Rent", 1000, 1200]);
+  ws.addRow(["Utilities", 300, 320]);
+  const data = await workbook.xlsx.writeBuffer();
+  return Buffer.from(data);
+}
+
+function createPrismaMock(): PrismaClient {
+  const mock = {
+    snapshot: {
+      findUnique: vi.fn().mockResolvedValue({ id: "snap-1", status: "draft", createdBy: "user-1" })
+    },
+    group: {
+      count: vi.fn().mockResolvedValue(0),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "group-1", name: "Residential Properties" })
+    },
+    lineItem: {
+      count: vi.fn().mockResolvedValue(0),
+      findFirst: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: "li-1", label: "Base Rent" })
+    },
+    value: {
+      upsert: vi.fn().mockResolvedValue({})
+    }
+  };
+
+  return mock as unknown as PrismaClient;
+}
+
+describe("ExcelImportService", () => {
+  it("parses workbook into groups, line items, and periods", async () => {
+    const service = new ExcelImportService(createPrismaMock());
+    const parsed = await service.parseWorkbook(await buildWorkbookBuffer());
+
+    expect(parsed.groups).toHaveLength(1);
+    expect(parsed.groups[0].lineItems).toHaveLength(2);
+    expect(parsed.periods).toEqual(["2026-01", "2026-02"]);
+    expect(parsed.warnings).toEqual([]);
+  });
+
+  it("returns summary counts", async () => {
+    const service = new ExcelImportService(createPrismaMock());
+    const parsed = await service.parseWorkbook(await buildWorkbookBuffer());
+    const summary = service.summarize(parsed);
+
+    expect(summary.groupCount).toBe(1);
+    expect(summary.lineItemCount).toBe(2);
+    expect(summary.valueCount).toBe(4);
+  });
+
+  it("confirms import by upserting values into target snapshot", async () => {
+    const prisma = createPrismaMock();
+    const service = new ExcelImportService(prisma);
+    const parsed = await service.parseWorkbook(await buildWorkbookBuffer());
+    const summary = await service.confirmImport("snap-1", parsed);
+
+    expect(summary.snapshotId).toBe("snap-1");
+    expect(prisma.value.upsert).toHaveBeenCalledTimes(4);
+  });
+});


### PR DESCRIPTION
## Summary

- Issue: Closes #77
- Scope:
  - Added `POST /api/imports/excel` multipart upload route.
  - Implemented Excel parsing/import service with:
    - Preview mode (parse + summary, no writes)
    - Confirm mode (upsert groups, line items, values into target snapshot)
    - Validation/error handling for malformed workbook and invalid inputs
  - Added upload/preview/confirm UI section to admin line-items page.
  - Added unit tests for service parsing/confirm flow and route validation.

## Review Findings

- [x] Reviewer findings captured (or "No findings")
- [ ] Findings addressed with follow-up commits

## Validation

- [x] `npm run lint` (warnings only)
- [ ] `npm run typecheck` (blocked by pre-existing main error in `lib/snapshots/compare-service.ts:164`)
- [x] `npm run test:ci`
- [ ] `npm run build`

## Tests

- [x] Tests added/updated for changed behavior
- [ ] If no tests were added, include justification and add `[no-tests]` token here

## Risk Check

- [x] Backward compatibility assessed
- [x] Security/permission changes assessed
- [x] Data model or migration impact assessed

## Notes for Reviewer

- Focus areas:
  - Parsing heuristics in `lib/imports/excel-import-service.ts` (header row detection, period parsing, row filtering)
  - Confirm-mode upsert semantics and snapshot lock/not-found validation
  - Admin UI integration in `app/admin/line-items/page.tsx`
- Known limitations:
  - Parser is schema-agnostic and heuristic-based; unusual workbook layouts may require explicit mapping rules.
  - Typecheck block comes from existing unrelated file on `main`.
